### PR TITLE
fix: request Indexing API scope (fixes #2)

### DIFF
--- a/dist/auth.js
+++ b/dist/auth.js
@@ -84,6 +84,7 @@ async function getServiceAccountClient() {
         scopes: [
             "https://www.googleapis.com/auth/webmasters.readonly",
             "https://www.googleapis.com/auth/webmasters",
+            "https://www.googleapis.com/auth/indexing",
         ],
     });
     googleapis_1.google.options({ auth });

--- a/dist/oauth.js
+++ b/dist/oauth.js
@@ -173,6 +173,7 @@ async function runBrowserAuth(oauth2Client, callbackPort, redirectUri) {
                 scope: [
                     "https://www.googleapis.com/auth/webmasters.readonly",
                     "https://www.googleapis.com/auth/webmasters",
+                    "https://www.googleapis.com/auth/indexing",
                 ],
                 prompt: "consent",
             });

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -61,6 +61,7 @@ async function getServiceAccountClient(): Promise<searchconsole_v1.Searchconsole
     scopes: [
       "https://www.googleapis.com/auth/webmasters.readonly",
       "https://www.googleapis.com/auth/webmasters",
+      "https://www.googleapis.com/auth/indexing",
     ],
   });
 

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -166,6 +166,7 @@ async function runBrowserAuth(
         scope: [
           "https://www.googleapis.com/auth/webmasters.readonly",
           "https://www.googleapis.com/auth/webmasters",
+          "https://www.googleapis.com/auth/indexing",
         ],
         prompt: "consent",
       });


### PR DESCRIPTION
## Summary

- Adds `https://www.googleapis.com/auth/indexing` to the OAuth scope list ([`src/oauth.ts`](https://github.com/Suganthan-Mohanadasan/Suganthans-GSC-MCP/blob/main/src/oauth.ts#L165-L168)) and the service-account scope list ([`src/auth.ts`](https://github.com/Suganthan-Mohanadasan/Suganthans-GSC-MCP/blob/main/src/auth.ts#L61-L64)).
- Regenerates the corresponding `dist/oauth.js` and `dist/auth.js` (since `dist/` is tracked in this repo).

Without this scope, `submit_url` and `submit_batch` always fail with HTTP 403 "Insufficient Permission" — the access token simply cannot reach `indexing.googleapis.com`. See #2 for the full repro and evidence.

The change is 4 added lines total — one per file.

## Test plan

- [x] Built locally (`npm run build`) — TypeScript compiles cleanly.
- [x] Verified the new scope appears in `dist/oauth.js` and `dist/auth.js`.
- [x] End-to-end verified on a live property: after applying this patch + clearing the cached token at `~/.gsc-mcp/oauth-token.json`, the OAuth consent screen now lists three permissions (was two), and a 30-URL `submit_batch` call returns `success: true` for all 30 — same call returned 403 for all 30 before the patch.
- [ ] (Maintainer) confirm the OAuth consent screen for any new GCP project lists `auth/indexing` in its allowed scopes — this is a one-time GCP-side step independent of the MCP, but worth documenting in the README alongside the existing "enable the Web Search Indexing API" instruction.

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)