### PR TITLE
fix: add indexing scope to OAuth flow so submit_url works

### DIFF
--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -166,6 +166,11 @@ async function runBrowserAuth(
         scope: [
           "https://www.googleapis.com/auth/webmasters.readonly",
           "https://www.googleapis.com/auth/webmasters",
+          // Required for the submit_url / submit_batch tools (Indexing API).
+          // Without this scope the token issued by the OAuth flow cannot call
+          // indexing.urlNotifications.publish, and submissions fail with
+          // "Insufficient Permission" even when the Indexing API is enabled.
+          "https://www.googleapis.com/auth/indexing",
         ],
         prompt: "consent",
       });


### PR DESCRIPTION
## The bug

In OAuth mode, \`submit_url\` and \`submit_batch\` always fail with \`Insufficient Permission\`, even when the Indexing API is enabled in the Google Cloud project and the user has owner access in Search Console.

## Why

\`src/oauth.ts\` requests only \`webmasters\` and \`webmasters.readonly\` scopes during the consent flow:

\`\`\`ts
scope: [
  \"https://www.googleapis.com/auth/webmasters.readonly\",
  \"https://www.googleapis.com/auth/webmasters\",
],
\`\`\`

\`tools/submit-url.ts\` then reuses the same \`oauth2Client\` for the Indexing API:

\`\`\`ts
if (mode === \"oauth\") {
  const oauth2Client = await authenticateWithOAuth();
  google.options({ auth: oauth2Client });
}
\`\`\`

The token issued during consent doesn't include \`https://www.googleapis.com/auth/indexing\`, so \`indexing.urlNotifications.publish\` rejects the call.

The service-account branch already creates a fresh \`GoogleAuth\` with the indexing scope inline, which is why service-account mode works.

## The fix

Add \`https://www.googleapis.com/auth/indexing\` to the scope list in \`runBrowserAuth\`. Existing users need to re-consent once (delete \`~/.gsc-mcp/oauth-token.json\`), since the cached token won't get the new scope from a silent refresh.

## Verification

After the patch, the token cached at \`~/.gsc-mcp/oauth-token.json\` includes all three scopes:

\`\`\`
scope: https://www.googleapis.com/auth/webmasters.readonly https://www.googleapis.com/auth/webmasters https://www.googleapis.com/auth/indexing
\`\`\`

And \`submit_url\` returns \`success: true\` with a \`notifyTime\` for both \`URL_UPDATED\` and \`URL_DELETED\` actions.

## Notes

- This is a small, additive change. No behavior change for the existing read/write tools.
- The new scope appears on the consent screen as \"Submit URLs to Google's Indexing API\"; users who don't intend to use \`submit_url\`/\`submit_batch\` can still grant it without affecting other tools.
- Service-account mode is unchanged (already working).

🤖 Generated with [Claude Code](https://claude.com/claude-code)