### PR TITLE
feat: Discover, Image, Video, News & search-appearance surfaces + query_count tool

### DIFF
--- a/dist/analytics.d.ts
+++ b/dist/analytics.d.ts
@@ -1,3 +1,15 @@
+/**
+ * GSC search types. The API defaults to "web" when type is omitted, which is
+ * why every legacy tool only ever sees web data. Set this explicitly to query
+ * Discover, Image, Video or News surfaces in isolation.
+ */
+export type SearchType = "web" | "image" | "video" | "news" | "discover" | "googleNews";
+/**
+ * Dimensions the API actually allows per surface. Used for a friendly guard so
+ * an invalid combination fails with a clear message instead of an opaque 400.
+ * (searchAppearance is special: it must be the ONLY grouping dimension.)
+ */
+export declare const ALLOWED_DIMENSIONS: Record<SearchType, string[]>;
 export interface SearchAnalyticsRow {
     keys: string[];
     clicks: number;
@@ -9,6 +21,8 @@ export interface QueryParams {
     startDate: string;
     endDate: string;
     dimensions: string[];
+    /** Surface to query. Omit for "web" (the API default). */
+    searchType?: SearchType;
     dimensionFilterGroups?: Array<{
         filters: Array<{
             dimension: string;
@@ -18,6 +32,11 @@ export interface QueryParams {
     }>;
     rowLimit?: number;
 }
+/**
+ * Validates that the requested dimensions are legal for the chosen surface.
+ * Throws a descriptive error instead of letting the API return a generic 400.
+ */
+export declare function assertValidDimensions(searchType: SearchType, dimensions: string[]): void;
 export declare function getDateRange(days: number): {
     startDate: string;
     endDate: string;

--- a/dist/analytics.d.ts
+++ b/dist/analytics.d.ts
@@ -31,6 +31,8 @@ export interface QueryParams {
         }>;
     }>;
     rowLimit?: number;
+    /** Hard cap on rows fetched across all pages. Omit for no cap. */
+    maxRows?: number;
 }
 /**
  * Validates that the requested dimensions are legal for the chosen surface.

--- a/dist/analytics.d.ts
+++ b/dist/analytics.d.ts
@@ -39,6 +39,23 @@ export interface QueryParams {
  * Throws a descriptive error instead of letting the API return a generic 400.
  */
 export declare function assertValidDimensions(searchType: SearchType, dimensions: string[]): void;
+/** Devices as the API spells them in dimension filters. */
+export declare const DEVICES: readonly ["MOBILE", "DESKTOP", "TABLET"];
+export type Device = (typeof DEVICES)[number];
+/**
+ * Dimension filters for device and country.
+ *
+ * Both are optional, and unset means unfiltered - every tool keeps returning
+ * all devices and all countries unless asked otherwise.
+ *
+ * Discover has no device dimension (see ALLOWED_DIMENSIONS), so filtering by
+ * device there is impossible rather than merely empty. That fails loudly.
+ */
+export declare function deviceCountryFilters(device?: string, country?: string, searchType?: SearchType): Array<{
+    dimension: string;
+    operator: string;
+    expression: string;
+}>;
 export declare function getDateRange(days: number): {
     startDate: string;
     endDate: string;

--- a/dist/analytics.js
+++ b/dist/analytics.js
@@ -1,9 +1,41 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.ALLOWED_DIMENSIONS = void 0;
+exports.assertValidDimensions = assertValidDimensions;
 exports.getDateRange = getDateRange;
 exports.getPriorDateRange = getPriorDateRange;
 exports.fetchAllRows = fetchAllRows;
 const auth_js_1 = require("./auth.js");
+/**
+ * Dimensions the API actually allows per surface. Used for a friendly guard so
+ * an invalid combination fails with a clear message instead of an opaque 400.
+ * (searchAppearance is special: it must be the ONLY grouping dimension.)
+ */
+exports.ALLOWED_DIMENSIONS = {
+    web: ["query", "page", "country", "device", "date", "searchAppearance"],
+    image: ["query", "page", "country", "device", "date", "searchAppearance"],
+    video: ["query", "page", "country", "device", "date", "searchAppearance"],
+    news: ["query", "page", "country", "device", "date"],
+    // Discover is not query-based: no "query", no "device".
+    discover: ["page", "country", "date", "searchAppearance"],
+    googleNews: ["page", "country", "date"],
+};
+/**
+ * Validates that the requested dimensions are legal for the chosen surface.
+ * Throws a descriptive error instead of letting the API return a generic 400.
+ */
+function assertValidDimensions(searchType, dimensions) {
+    const allowed = exports.ALLOWED_DIMENSIONS[searchType];
+    const invalid = dimensions.filter((d) => !allowed.includes(d));
+    if (invalid.length > 0) {
+        throw new Error(`Dimension(s) [${invalid.join(", ")}] are not supported for searchType "${searchType}". ` +
+            `Allowed: [${allowed.join(", ")}].`);
+    }
+    if (dimensions.includes("searchAppearance") && dimensions.length > 1) {
+        throw new Error(`"searchAppearance" must be the only grouping dimension. ` +
+            `To break a single appearance down by page/query, filter on searchAppearance instead.`);
+    }
+}
 function formatDate(date) {
     return date.toISOString().split("T")[0];
 }
@@ -48,6 +80,7 @@ async function fetchAllRows(params, siteUrlOverride) {
                 startDate: params.startDate,
                 endDate: params.endDate,
                 dimensions: params.dimensions,
+                type: params.searchType, // undefined => API default "web"
                 dimensionFilterGroups: params.dimensionFilterGroups,
                 rowLimit: pageSize,
                 startRow,

--- a/dist/analytics.js
+++ b/dist/analytics.js
@@ -101,7 +101,9 @@ async function fetchAllRows(params, siteUrlOverride) {
         }
         if (rows.length < pageSize)
             break;
+        if (params.maxRows && allRows.length >= params.maxRows)
+            break;
         startRow += pageSize;
     }
-    return allRows;
+    return params.maxRows ? allRows.slice(0, params.maxRows) : allRows;
 }

--- a/dist/analytics.js
+++ b/dist/analytics.js
@@ -1,7 +1,8 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.ALLOWED_DIMENSIONS = void 0;
+exports.DEVICES = exports.ALLOWED_DIMENSIONS = void 0;
 exports.assertValidDimensions = assertValidDimensions;
+exports.deviceCountryFilters = deviceCountryFilters;
 exports.getDateRange = getDateRange;
 exports.getPriorDateRange = getPriorDateRange;
 exports.fetchAllRows = fetchAllRows;
@@ -35,6 +36,39 @@ function assertValidDimensions(searchType, dimensions) {
         throw new Error(`"searchAppearance" must be the only grouping dimension. ` +
             `To break a single appearance down by page/query, filter on searchAppearance instead.`);
     }
+}
+/** Devices as the API spells them in dimension filters. */
+exports.DEVICES = ["MOBILE", "DESKTOP", "TABLET"];
+/**
+ * Dimension filters for device and country.
+ *
+ * Both are optional, and unset means unfiltered - every tool keeps returning
+ * all devices and all countries unless asked otherwise.
+ *
+ * Discover has no device dimension (see ALLOWED_DIMENSIONS), so filtering by
+ * device there is impossible rather than merely empty. That fails loudly.
+ */
+function deviceCountryFilters(device, country, searchType = "web") {
+    const filters = [];
+    if (device) {
+        if (!exports.ALLOWED_DIMENSIONS[searchType].includes("device")) {
+            throw new Error(`searchType "${searchType}" has no device dimension, so it cannot be filtered by device. ` +
+                `Allowed dimensions: [${exports.ALLOWED_DIMENSIONS[searchType].join(", ")}].`);
+        }
+        const upper = device.toUpperCase();
+        if (!exports.DEVICES.includes(upper)) {
+            throw new Error(`Unknown device "${device}". Allowed: ${exports.DEVICES.join(", ")}.`);
+        }
+        filters.push({ dimension: "device", operator: "equals", expression: upper });
+    }
+    if (country) {
+        const lower = country.toLowerCase();
+        if (!/^[a-z]{3}$/.test(lower)) {
+            throw new Error(`Country must be an ISO-3166-1 alpha-3 code such as deu, aut, che or usa - got "${country}".`);
+        }
+        filters.push({ dimension: "country", operator: "equals", expression: lower });
+    }
+    return filters;
 }
 function formatDate(date) {
     return date.toISOString().split("T")[0];

--- a/dist/index.js
+++ b/dist/index.js
@@ -23,18 +23,27 @@ const generate_report_js_1 = require("./tools/generate-report.js");
 const multi_site_dashboard_js_1 = require("./tools/multi-site-dashboard.js");
 const submit_url_js_1 = require("./tools/submit-url.js");
 const submit_sitemap_js_1 = require("./tools/submit-sitemap.js");
+const discover_analysis_js_1 = require("./tools/discover-analysis.js");
+const image_analysis_js_1 = require("./tools/image-analysis.js");
+const search_appearance_js_1 = require("./tools/search-appearance.js");
 const server = new mcp_js_1.McpServer({
     name: "gsc-mcp",
     version: "2.1.0",
 });
+// Shared GSC surface (search type) parameter. "web" is the API default and keeps
+// every tool backwards-compatible. Page-based tools also accept "discover";
+// query-based tools accept image/video/news but not discover (no query dimension).
+const SURFACES = ["web", "image", "video", "news", "discover", "googleNews"];
+const surfaceParam = (note) => zod_1.z.enum(SURFACES).default("web").describe(note);
 // 1. Quick Wins
 server.tool("quick_wins", "Find keywords you're almost ranking for that could be pushed to page one. Returns queries at positions 4-15 with high impressions, sorted by traffic opportunity." + guardrails_js_1.GUARDRAIL_SUFFIX + guardrails_js_1.VISUAL_SUFFIX, {
     days: zod_1.z.number().default(28).describe("Number of days to analyse"),
     min_impressions: zod_1.z.number().default(100).describe("Minimum impressions threshold"),
     max_position: zod_1.z.number().default(15).describe("Maximum position to include"),
-}, async ({ days, min_impressions, max_position }) => {
-    const results = await (0, quick_wins_js_1.quickWins)(days, min_impressions, max_position);
-    const wrapped = (0, guardrails_js_1.withMeta)(results, "quick_wins", { days, min_impressions, max_position });
+    surface: surfaceParam("Surface to query: web (default), image, video, news. Discover is NOT supported here (no query dimension)."),
+}, async ({ days, min_impressions, max_position, surface }) => {
+    const results = await (0, quick_wins_js_1.quickWins)(days, min_impressions, max_position, surface);
+    const wrapped = (0, guardrails_js_1.withMeta)(results, "quick_wins", { days, min_impressions, max_position, surface });
     return {
         content: [{ type: "text", text: JSON.stringify(wrapped, null, 2) }],
     };
@@ -43,9 +52,10 @@ server.tool("quick_wins", "Find keywords you're almost ranking for that could be
 server.tool("ctr_opportunities", "Find pages with high impressions but CTR significantly below expected for their position. These are title/meta description optimisation candidates." + guardrails_js_1.GUARDRAIL_SUFFIX + guardrails_js_1.VISUAL_SUFFIX, {
     days: zod_1.z.number().default(28).describe("Number of days to analyse"),
     min_impressions: zod_1.z.number().default(500).describe("Minimum impressions threshold"),
-}, async ({ days, min_impressions }) => {
-    const results = await (0, ctr_opportunities_js_1.ctrOpportunities)(days, min_impressions);
-    const wrapped = (0, guardrails_js_1.withMeta)(results, "ctr_opportunities", { days, min_impressions });
+    surface: surfaceParam("Surface to query: web (default), image, video, news, discover. Discover is page-based and supported."),
+}, async ({ days, min_impressions, surface }) => {
+    const results = await (0, ctr_opportunities_js_1.ctrOpportunities)(days, min_impressions, surface);
+    const wrapped = (0, guardrails_js_1.withMeta)(results, "ctr_opportunities", { days, min_impressions, surface });
     return {
         content: [{ type: "text", text: JSON.stringify(wrapped, null, 2) }],
     };
@@ -53,9 +63,10 @@ server.tool("ctr_opportunities", "Find pages with high impressions but CTR signi
 // 3. Traffic Drops
 server.tool("traffic_drops", "Find pages that lost the most traffic recently. Compares current period vs prior period and diagnoses whether each drop is a ranking loss, CTR collapse, or demand decline." + guardrails_js_1.GUARDRAIL_SUFFIX + guardrails_js_1.VISUAL_SUFFIX, {
     days: zod_1.z.number().default(28).describe("Number of days per period to compare"),
-}, async ({ days }) => {
-    const results = await (0, traffic_drops_js_1.trafficDrops)(days);
-    const wrapped = (0, guardrails_js_1.withMeta)(results, "traffic_drops", { days });
+    surface: surfaceParam("Surface to query: web (default), image, video, news, discover. Discover is page-based and supported."),
+}, async ({ days, surface }) => {
+    const results = await (0, traffic_drops_js_1.trafficDrops)(days, surface);
+    const wrapped = (0, guardrails_js_1.withMeta)(results, "traffic_drops", { days, surface });
     return {
         content: [{ type: "text", text: JSON.stringify(wrapped, null, 2) }],
     };
@@ -65,9 +76,10 @@ server.tool("content_gaps", "Find topics you should create content for. Returns 
     days: zod_1.z.number().default(90).describe("Number of days to analyse"),
     min_impressions: zod_1.z.number().default(50).describe("Minimum impressions threshold"),
     min_position: zod_1.z.number().default(20).describe("Minimum position (queries ranking worse than this)"),
-}, async ({ days, min_impressions, min_position }) => {
-    const results = await (0, content_gaps_js_1.contentGaps)(days, min_impressions, min_position);
-    const wrapped = (0, guardrails_js_1.withMeta)(results, "content_gaps", { days, min_impressions, min_position });
+    surface: surfaceParam("Surface to query: web (default), image, video, news. Discover is NOT supported here (no query dimension)."),
+}, async ({ days, min_impressions, min_position, surface }) => {
+    const results = await (0, content_gaps_js_1.contentGaps)(days, min_impressions, min_position, surface);
+    const wrapped = (0, guardrails_js_1.withMeta)(results, "content_gaps", { days, min_impressions, min_position, surface });
     return {
         content: [{ type: "text", text: JSON.stringify(wrapped, null, 2) }],
     };
@@ -96,17 +108,20 @@ server.tool("inspect_url", "Check if a URL is indexed and why or why not. Return
 server.tool("cannibalization_check", "Find keywords where multiple pages from your site compete against each other. Shows which page ranks higher, the position gap, and combined impressions being split." + guardrails_js_1.GUARDRAIL_SUFFIX + guardrails_js_1.VISUAL_SUFFIX, {
     days: zod_1.z.number().default(28).describe("Number of days to analyse"),
     min_impressions: zod_1.z.number().default(50).describe("Minimum combined impressions for a query"),
-}, async ({ days, min_impressions }) => {
-    const results = await (0, cannibalization_check_js_1.cannibalizationCheck)(days, min_impressions);
-    const wrapped = (0, guardrails_js_1.withMeta)(results, "cannibalization_check", { days, min_impressions });
+    surface: surfaceParam("Surface to query: web (default), image, video, news. Discover is NOT supported here (no query dimension)."),
+}, async ({ days, min_impressions, surface }) => {
+    const results = await (0, cannibalization_check_js_1.cannibalizationCheck)(days, min_impressions, surface);
+    const wrapped = (0, guardrails_js_1.withMeta)(results, "cannibalization_check", { days, min_impressions, surface });
     return {
         content: [{ type: "text", text: JSON.stringify(wrapped, null, 2) }],
     };
 });
 // 8. Content Decay
-server.tool("content_decay", "Find pages that are slowly dying with consistent traffic decline over three consecutive 30-day periods. One bad month is noise; three consecutive bad months is a problem." + guardrails_js_1.GUARDRAIL_SUFFIX + guardrails_js_1.VISUAL_SUFFIX, {}, async () => {
-    const results = await (0, content_decay_js_1.contentDecay)();
-    const wrapped = (0, guardrails_js_1.withMeta)(results, "content_decay", {});
+server.tool("content_decay", "Find pages that are slowly dying with consistent traffic decline over three consecutive 30-day periods. One bad month is noise; three consecutive bad months is a problem." + guardrails_js_1.GUARDRAIL_SUFFIX + guardrails_js_1.VISUAL_SUFFIX, {
+    surface: surfaceParam("Surface to query: web (default), image, video, news, discover. Discover is page-based and supported."),
+}, async ({ surface }) => {
+    const results = await (0, content_decay_js_1.contentDecay)(surface);
+    const wrapped = (0, guardrails_js_1.withMeta)(results, "content_decay", { surface });
     return {
         content: [{ type: "text", text: JSON.stringify(wrapped, null, 2) }],
     };
@@ -115,9 +130,10 @@ server.tool("content_decay", "Find pages that are slowly dying with consistent t
 server.tool("topic_cluster_performance", "See how a group of pages performs as a whole. Aggregates clicks, impressions, CTR, and position for all pages matching a URL path pattern, plus top 5 pages and queries." + guardrails_js_1.GUARDRAIL_SUFFIX + guardrails_js_1.VISUAL_SUFFIX, {
     path_pattern: zod_1.z.string().describe("URL path pattern to match (e.g. /blog/seo)"),
     days: zod_1.z.number().default(28).describe("Number of days to analyse"),
-}, async ({ path_pattern, days }) => {
-    const results = await (0, topic_cluster_performance_js_1.topicClusterPerformance)(path_pattern, days);
-    const wrapped = (0, guardrails_js_1.withMeta)(results, "topic_cluster_performance", { path_pattern, days });
+    surface: surfaceParam("Surface to query: web (default), image, video, news, discover. On Discover only page-level data is returned (no queries)."),
+}, async ({ path_pattern, days, surface }) => {
+    const results = await (0, topic_cluster_performance_js_1.topicClusterPerformance)(path_pattern, days, surface);
+    const wrapped = (0, guardrails_js_1.withMeta)(results, "topic_cluster_performance", { path_pattern, days, surface });
     return {
         content: [{ type: "text", text: JSON.stringify(wrapped, null, 2) }],
     };
@@ -126,9 +142,10 @@ server.tool("topic_cluster_performance", "See how a group of pages performs as a
 server.tool("ctr_vs_benchmark", "Compare your actual CTR per page against industry benchmarks by position. Flags pages significantly underperforming for their ranking position." + guardrails_js_1.GUARDRAIL_SUFFIX + guardrails_js_1.VISUAL_SUFFIX, {
     days: zod_1.z.number().default(28).describe("Number of days to analyse"),
     min_impressions: zod_1.z.number().default(200).describe("Minimum impressions threshold"),
-}, async ({ days, min_impressions }) => {
-    const results = await (0, ctr_vs_benchmark_js_1.ctrVsBenchmark)(days, min_impressions);
-    const wrapped = (0, guardrails_js_1.withMeta)(results, "ctr_vs_benchmark", { days, min_impressions });
+    surface: surfaceParam("Surface to query: web (default), image, video, news, discover. Discover is page-based and supported."),
+}, async ({ days, min_impressions, surface }) => {
+    const results = await (0, ctr_vs_benchmark_js_1.ctrVsBenchmark)(days, min_impressions, surface);
+    const wrapped = (0, guardrails_js_1.withMeta)(results, "ctr_vs_benchmark", { days, min_impressions, surface });
     return {
         content: [{ type: "text", text: JSON.stringify(wrapped, null, 2) }],
     };
@@ -141,8 +158,9 @@ server.tool("verify_claim", "Verify a specific numeric claim against live GSC da
     url: zod_1.z.string().optional().describe("Filter to a specific URL"),
     query: zod_1.z.string().optional().describe("Filter to a specific search query"),
     days: zod_1.z.number().default(28).describe("Number of days to check"),
-}, async ({ claim, metric, expected_value, url, query, days }) => {
-    const results = await (0, verify_claim_js_1.verifyClaim)(claim, metric, expected_value, url, query, days);
+    surface: surfaceParam("Surface to query: web (default), image, video, news, discover. On Discover only page-level data is returned (no queries)."),
+}, async ({ claim, metric, expected_value, url, query, days, surface }) => {
+    const results = await (0, verify_claim_js_1.verifyClaim)(claim, metric, expected_value, url, query, days, surface);
     return {
         content: [{ type: "text", text: JSON.stringify(results, null, 2) }],
     };
@@ -160,9 +178,10 @@ server.tool("advanced_search_analytics", "Run a custom search analytics query wi
     order_by: zod_1.z.string().default("clicks").describe("Sort by: clicks, impressions, ctr, position"),
     order_direction: zod_1.z.string().default("descending").describe("Sort direction: ascending, descending"),
     site_url: zod_1.z.string().optional().describe("Override the default site URL"),
-}, async ({ days, dimensions, filters, row_limit, order_by, order_direction, site_url }) => {
-    const results = await (0, advanced_search_analytics_js_1.advancedSearchAnalytics)(days, dimensions, filters, row_limit, order_by, order_direction, site_url);
-    const wrapped = (0, guardrails_js_1.withMeta)(results, "advanced_search_analytics", { days, dimensions, filters, row_limit, order_by });
+    surface: surfaceParam("Surface to query: web (default), image, video, news, discover, googleNews. Dimensions must be valid for the chosen surface."),
+}, async ({ days, dimensions, filters, row_limit, order_by, order_direction, site_url, surface }) => {
+    const results = await (0, advanced_search_analytics_js_1.advancedSearchAnalytics)(days, dimensions, filters, row_limit, order_by, order_direction, site_url, surface);
+    const wrapped = (0, guardrails_js_1.withMeta)(results, "advanced_search_analytics", { days, dimensions, filters, row_limit, order_by, surface });
     return {
         content: [{ type: "text", text: JSON.stringify(wrapped, null, 2) }],
     };
@@ -173,9 +192,10 @@ server.tool("check_alerts", "Check for SEO alerts: position drops, CTR collapses
     position_drop_threshold: zod_1.z.number().default(20).describe("Alert if position drops more than this many spots"),
     ctr_drop_threshold: zod_1.z.number().default(50).describe("Alert if CTR drops more than this percentage"),
     click_drop_threshold: zod_1.z.number().default(30).describe("Alert if clicks drop more than this percentage"),
-}, async ({ days, position_drop_threshold, ctr_drop_threshold, click_drop_threshold }) => {
-    const results = await (0, check_alerts_js_1.checkAlerts)(days, position_drop_threshold, ctr_drop_threshold, click_drop_threshold);
-    const wrapped = (0, guardrails_js_1.withMeta)(results, "check_alerts", { days, position_drop_threshold, ctr_drop_threshold, click_drop_threshold });
+    surface: surfaceParam("Surface to query: web (default), image, video, news. Discover is NOT supported here (no query dimension)."),
+}, async ({ days, position_drop_threshold, ctr_drop_threshold, click_drop_threshold, surface }) => {
+    const results = await (0, check_alerts_js_1.checkAlerts)(days, position_drop_threshold, ctr_drop_threshold, click_drop_threshold, surface);
+    const wrapped = (0, guardrails_js_1.withMeta)(results, "check_alerts", { days, position_drop_threshold, ctr_drop_threshold, click_drop_threshold, surface });
     return {
         content: [{ type: "text", text: JSON.stringify(wrapped, null, 2) }],
     };
@@ -246,6 +266,45 @@ server.tool("submit_sitemap", "Notify Google of a new or updated sitemap. Trigge
 server.tool("list_sitemaps", "List all sitemaps submitted for the site, with status, errors, warnings, and indexed page counts." + guardrails_js_1.GUARDRAIL_SUFFIX, {}, async () => {
     const results = await (0, submit_sitemap_js_1.listSitemaps)();
     const wrapped = (0, guardrails_js_1.withMeta)(results, "list_sitemaps", {});
+    return {
+        content: [{ type: "text", text: JSON.stringify(wrapped, null, 2) }],
+    };
+});
+// 21. Discover Analysis (isolated)
+server.tool("discover_analysis", "Analyse Google Discover performance in isolation (type=discover). Discover is feed-based, not query-based, so this returns top pages, country split and a daily clicks/impressions trend with a prior-period comparison. No query-level data or position exists for Discover." + guardrails_js_1.GUARDRAIL_SUFFIX + guardrails_js_1.VISUAL_SUFFIX, {
+    days: zod_1.z.number().default(28).describe("Number of days per period to compare"),
+    row_limit: zod_1.z.number().default(50).describe("Max number of top pages to return"),
+    site_url: zod_1.z.string().optional().describe("Override the configured property"),
+}, async ({ days, row_limit, site_url }) => {
+    const results = await (0, discover_analysis_js_1.discoverAnalysis)(days, row_limit, site_url);
+    const wrapped = (0, guardrails_js_1.withMeta)(results, "discover_analysis", { days, row_limit, site_url });
+    return {
+        content: [{ type: "text", text: JSON.stringify(wrapped, null, 2) }],
+    };
+});
+// 22. Image Analysis (isolated)
+server.tool("image_analysis", "Analyse Google Image search performance in isolation (type=image). Returns top image queries, top pages and a prior-period comparison. Separate from web search data." + guardrails_js_1.GUARDRAIL_SUFFIX + guardrails_js_1.VISUAL_SUFFIX, {
+    days: zod_1.z.number().default(28).describe("Number of days per period to compare"),
+    row_limit: zod_1.z.number().default(50).describe("Max number of top queries/pages to return"),
+    site_url: zod_1.z.string().optional().describe("Override the configured property"),
+}, async ({ days, row_limit, site_url }) => {
+    const results = await (0, image_analysis_js_1.imageAnalysis)(days, row_limit, site_url);
+    const wrapped = (0, guardrails_js_1.withMeta)(results, "image_analysis", { days, row_limit, site_url });
+    return {
+        content: [{ type: "text", text: JSON.stringify(wrapped, null, 2) }],
+    };
+});
+// 23. Search Appearance / Merchant Listings (isolated)
+server.tool("search_appearance", "Break down performance by search-appearance / rich-result type (the searchAppearance dimension), e.g. MERCHANT_LISTINGS (Händlereinträge), PRODUCT_SNIPPETS, REVIEW_SNIPPET, RECIPE_FEATURE. Without an appearance argument it lists all appearance types with their metrics. Pass an appearance value to drill into the pages or queries driving that specific type." + guardrails_js_1.GUARDRAIL_SUFFIX + guardrails_js_1.VISUAL_SUFFIX, {
+    days: zod_1.z.number().default(28).describe("Number of days to analyse"),
+    appearance: zod_1.z.string().optional().describe("Appearance type to drill into, e.g. MERCHANT_LISTINGS. Omit for the full breakdown."),
+    drill_dimension: zod_1.z.enum(["page", "query"]).default("page").describe("When drilling into an appearance, group by page or query"),
+    search_type: zod_1.z.enum(["web", "image", "video", "news", "discover", "googleNews"]).default("web").describe("Surface to query the appearance breakdown for"),
+    row_limit: zod_1.z.number().default(50).describe("Max number of drilldown rows to return"),
+    site_url: zod_1.z.string().optional().describe("Override the configured property"),
+}, async ({ days, appearance, drill_dimension, search_type, row_limit, site_url }) => {
+    const results = await (0, search_appearance_js_1.searchAppearance)(days, appearance, drill_dimension, search_type, row_limit, site_url);
+    const wrapped = (0, guardrails_js_1.withMeta)(results, "search_appearance", { days, appearance, drill_dimension, search_type, row_limit, site_url });
     return {
         content: [{ type: "text", text: JSON.stringify(wrapped, null, 2) }],
     };

--- a/dist/index.js
+++ b/dist/index.js
@@ -42,9 +42,11 @@ server.tool("quick_wins", "Find keywords you're almost ranking for that could be
     min_impressions: zod_1.z.number().default(100).describe("Minimum impressions threshold"),
     max_position: zod_1.z.number().default(15).describe("Maximum position to include"),
     surface: surfaceParam("Surface to query: web (default), image, video, news. Discover is NOT supported here (no query dimension)."),
-}, async ({ days, min_impressions, max_position, surface }) => {
-    const results = await (0, quick_wins_js_1.quickWins)(days, min_impressions, max_position, surface);
-    const wrapped = (0, guardrails_js_1.withMeta)(results, "quick_wins", { days, min_impressions, max_position, surface });
+    device: zod_1.z.enum(["MOBILE", "DESKTOP", "TABLET"]).optional().describe("Restrict to one device. Omit for all devices, which is the default. Not available on Discover, which carries no device dimension."),
+    country: zod_1.z.string().optional().describe("Restrict to one country as an ISO-3166-1 alpha-3 code, e.g. deu, aut, che. Omit for all countries, which is the default."),
+}, async ({ days, min_impressions, max_position, surface, device, country }) => {
+    const results = await (0, quick_wins_js_1.quickWins)(days, min_impressions, max_position, surface, device, country);
+    const wrapped = (0, guardrails_js_1.withMeta)(results, "quick_wins", { days, min_impressions, max_position, surface, device, country });
     return {
         content: [{ type: "text", text: JSON.stringify(wrapped, null, 2) }],
     };
@@ -54,9 +56,11 @@ server.tool("ctr_opportunities", "Find pages with high impressions but CTR signi
     days: zod_1.z.number().default(28).describe("Number of days to analyse"),
     min_impressions: zod_1.z.number().default(500).describe("Minimum impressions threshold"),
     surface: surfaceParam("Surface to query: web (default), image, video, news, discover. Discover is page-based and supported."),
-}, async ({ days, min_impressions, surface }) => {
-    const results = await (0, ctr_opportunities_js_1.ctrOpportunities)(days, min_impressions, surface);
-    const wrapped = (0, guardrails_js_1.withMeta)(results, "ctr_opportunities", { days, min_impressions, surface });
+    device: zod_1.z.enum(["MOBILE", "DESKTOP", "TABLET"]).optional().describe("Restrict to one device. Omit for all devices, which is the default. Not available on Discover, which carries no device dimension."),
+    country: zod_1.z.string().optional().describe("Restrict to one country as an ISO-3166-1 alpha-3 code, e.g. deu, aut, che. Omit for all countries, which is the default."),
+}, async ({ days, min_impressions, surface, device, country }) => {
+    const results = await (0, ctr_opportunities_js_1.ctrOpportunities)(days, min_impressions, surface, device, country);
+    const wrapped = (0, guardrails_js_1.withMeta)(results, "ctr_opportunities", { days, min_impressions, surface, device, country });
     return {
         content: [{ type: "text", text: JSON.stringify(wrapped, null, 2) }],
     };
@@ -120,9 +124,11 @@ server.tool("cannibalization_check", "Find keywords where multiple pages from yo
 // 8. Content Decay
 server.tool("content_decay", "Find pages that are slowly dying with consistent traffic decline over three consecutive 30-day periods. One bad month is noise; three consecutive bad months is a problem." + guardrails_js_1.GUARDRAIL_SUFFIX + guardrails_js_1.VISUAL_SUFFIX, {
     surface: surfaceParam("Surface to query: web (default), image, video, news, discover. Discover is page-based and supported."),
-}, async ({ surface }) => {
-    const results = await (0, content_decay_js_1.contentDecay)(surface);
-    const wrapped = (0, guardrails_js_1.withMeta)(results, "content_decay", { surface });
+    device: zod_1.z.enum(["MOBILE", "DESKTOP", "TABLET"]).optional().describe("Restrict to one device. Omit for all devices, which is the default. Not available on Discover, which carries no device dimension."),
+    country: zod_1.z.string().optional().describe("Restrict to one country as an ISO-3166-1 alpha-3 code, e.g. deu, aut, che. Omit for all countries, which is the default."),
+}, async ({ surface, device, country }) => {
+    const results = await (0, content_decay_js_1.contentDecay)(surface, device, country);
+    const wrapped = (0, guardrails_js_1.withMeta)(results, "content_decay", { surface, device, country });
     return {
         content: [{ type: "text", text: JSON.stringify(wrapped, null, 2) }],
     };
@@ -322,9 +328,11 @@ server.tool("query_count", "Count how many distinct queries a property, a sectio
     include_pages: zod_1.z.boolean().default(false).describe("Also rank pages by query count. Expensive: needs the page+query dimension pair, capped at 100k rows."),
     top_pages: zod_1.z.number().default(25).describe("How many pages to return when include_pages is true"),
     surface: surfaceParam("Surface to query: web (default), image, video, news. Discover is NOT supported here (no query dimension)."),
-}, async ({ days, url, url_contains, granularity, min_position, max_position, compare_previous, include_pages, top_pages, surface }) => {
-    const results = await (0, query_count_js_1.queryCount)(days, compare_previous, include_pages, top_pages, surface, url, url_contains, granularity, min_position, max_position);
-    const wrapped = (0, guardrails_js_1.withMeta)(results, "query_count", { days, url, url_contains, granularity, min_position, max_position, compare_previous, include_pages, top_pages, surface });
+    device: zod_1.z.enum(["MOBILE", "DESKTOP", "TABLET"]).optional().describe("Restrict to one device. Omit for all devices, which is the default. Not available on Discover, which carries no device dimension."),
+    country: zod_1.z.string().optional().describe("Restrict to one country as an ISO-3166-1 alpha-3 code, e.g. deu, aut, che. Omit for all countries, which is the default."),
+}, async ({ days, url, url_contains, granularity, min_position, max_position, compare_previous, include_pages, top_pages, surface, device, country }) => {
+    const results = await (0, query_count_js_1.queryCount)(days, compare_previous, include_pages, top_pages, surface, url, url_contains, granularity, min_position, max_position, device, country);
+    const wrapped = (0, guardrails_js_1.withMeta)(results, "query_count", { days, url, url_contains, granularity, min_position, max_position, compare_previous, include_pages, top_pages, surface, device, country });
     return {
         content: [{ type: "text", text: JSON.stringify(wrapped, null, 2) }],
     };

--- a/dist/index.js
+++ b/dist/index.js
@@ -26,9 +26,10 @@ const submit_sitemap_js_1 = require("./tools/submit-sitemap.js");
 const discover_analysis_js_1 = require("./tools/discover-analysis.js");
 const image_analysis_js_1 = require("./tools/image-analysis.js");
 const search_appearance_js_1 = require("./tools/search-appearance.js");
+const query_count_js_1 = require("./tools/query-count.js");
 const server = new mcp_js_1.McpServer({
     name: "gsc-mcp",
-    version: "2.1.0",
+    version: "2.4.0",
 });
 // Shared GSC surface (search type) parameter. "web" is the API default and keeps
 // every tool backwards-compatible. Page-based tools also accept "discover";
@@ -309,10 +310,24 @@ server.tool("search_appearance", "Break down performance by search-appearance / 
         content: [{ type: "text", text: JSON.stringify(wrapped, null, 2) }],
     };
 });
+// 24. Query Counting
+server.tool("query_count", "Count how many distinct queries the property is visible for, split by position group (1-3, 4-10, 11-20, 21-50, 51+), with a comparison to the previous period. Also reports the anonymized-click gap: clicks the site total contains but no query row explains, because those queries fall below Google's privacy threshold. Treat the query count as a floor, never as the complete keyword set." + guardrails_js_1.GUARDRAIL_SUFFIX + guardrails_js_1.VISUAL_SUFFIX, {
+    days: zod_1.z.number().default(28).describe("Number of days to analyse"),
+    compare_previous: zod_1.z.boolean().default(true).describe("Also count the immediately preceding period of the same length"),
+    include_pages: zod_1.z.boolean().default(false).describe("Also count queries per page. Expensive on large sites: needs the page+query dimension pair, capped at 100k rows."),
+    top_pages: zod_1.z.number().default(25).describe("How many pages to return when include_pages is true"),
+    surface: surfaceParam("Surface to query: web (default), image, video, news. Discover is NOT supported here (no query dimension)."),
+}, async ({ days, compare_previous, include_pages, top_pages, surface }) => {
+    const results = await (0, query_count_js_1.queryCount)(days, compare_previous, include_pages, top_pages, surface);
+    const wrapped = (0, guardrails_js_1.withMeta)(results, "query_count", { days, compare_previous, include_pages, top_pages, surface });
+    return {
+        content: [{ type: "text", text: JSON.stringify(wrapped, null, 2) }],
+    };
+});
 async function main() {
     const transport = new stdio_js_1.StdioServerTransport();
     await server.connect(transport);
-    console.error("GSC MCP server v2.1.0 running on stdio");
+    console.error("GSC MCP server v2.4.0 running on stdio");
 }
 main().catch((error) => {
     console.error("Fatal error:", error);

--- a/dist/index.js
+++ b/dist/index.js
@@ -311,15 +311,20 @@ server.tool("search_appearance", "Break down performance by search-appearance / 
     };
 });
 // 24. Query Counting
-server.tool("query_count", "Count how many distinct queries the property is visible for, split by position group (1-3, 4-10, 11-20, 21-50, 51+), with a comparison to the previous period. Also reports the anonymized-click gap: clicks the site total contains but no query row explains, because those queries fall below Google's privacy threshold. Treat the query count as a floor, never as the complete keyword set." + guardrails_js_1.GUARDRAIL_SUFFIX + guardrails_js_1.VISUAL_SUFFIX, {
+server.tool("query_count", "Count how many distinct queries a property, a section or a single URL is visible for, split by position group (1-3, 4-10, 11-20, 21-50, 51+). Scope it with url (one page) or url_contains (a path), turn it into a time series with granularity (day/week/month), and narrow it with min_position/max_position. Also reports the anonymized-click gap: clicks the totals contain but no query row explains, because those queries fall below Google's privacy threshold. The query count is a floor, never the complete keyword set." + guardrails_js_1.GUARDRAIL_SUFFIX + guardrails_js_1.VISUAL_SUFFIX, {
     days: zod_1.z.number().default(28).describe("Number of days to analyse"),
+    url: zod_1.z.string().optional().describe("Count only queries for this exact URL"),
+    url_contains: zod_1.z.string().optional().describe("Count only queries for URLs containing this string, e.g. /ratgeber/"),
+    granularity: zod_1.z.enum(["none", "day", "week", "month"]).default("none").describe("Return a time series of query counts. One API request per bucket, so day-level is capped at 90 days."),
+    min_position: zod_1.z.number().optional().describe("Only count queries at this average position or worse (e.g. 4)"),
+    max_position: zod_1.z.number().optional().describe("Only count queries at this average position or better (e.g. 10)"),
     compare_previous: zod_1.z.boolean().default(true).describe("Also count the immediately preceding period of the same length"),
-    include_pages: zod_1.z.boolean().default(false).describe("Also count queries per page. Expensive on large sites: needs the page+query dimension pair, capped at 100k rows."),
+    include_pages: zod_1.z.boolean().default(false).describe("Also rank pages by query count. Expensive: needs the page+query dimension pair, capped at 100k rows."),
     top_pages: zod_1.z.number().default(25).describe("How many pages to return when include_pages is true"),
     surface: surfaceParam("Surface to query: web (default), image, video, news. Discover is NOT supported here (no query dimension)."),
-}, async ({ days, compare_previous, include_pages, top_pages, surface }) => {
-    const results = await (0, query_count_js_1.queryCount)(days, compare_previous, include_pages, top_pages, surface);
-    const wrapped = (0, guardrails_js_1.withMeta)(results, "query_count", { days, compare_previous, include_pages, top_pages, surface });
+}, async ({ days, url, url_contains, granularity, min_position, max_position, compare_previous, include_pages, top_pages, surface }) => {
+    const results = await (0, query_count_js_1.queryCount)(days, compare_previous, include_pages, top_pages, surface, url, url_contains, granularity, min_position, max_position);
+    const wrapped = (0, guardrails_js_1.withMeta)(results, "query_count", { days, url, url_contains, granularity, min_position, max_position, compare_previous, include_pages, top_pages, surface });
     return {
         content: [{ type: "text", text: JSON.stringify(wrapped, null, 2) }],
     };

--- a/dist/tools/advanced-search-analytics.d.ts
+++ b/dist/tools/advanced-search-analytics.d.ts
@@ -1,3 +1,4 @@
+import { SearchType } from "../analytics.js";
 interface Filter {
     dimension: string;
     operator: string;
@@ -19,5 +20,5 @@ interface AdvancedSearchResult {
     };
     filtersApplied: Filter[];
 }
-export declare function advancedSearchAnalytics(days?: number, dimensions?: string[], filters?: Filter[], rowLimit?: number, orderBy?: string, orderDirection?: string, siteUrl?: string): Promise<AdvancedSearchResult>;
+export declare function advancedSearchAnalytics(days?: number, dimensions?: string[], filters?: Filter[], rowLimit?: number, orderBy?: string, orderDirection?: string, siteUrl?: string, searchType?: SearchType): Promise<AdvancedSearchResult>;
 export {};

--- a/dist/tools/advanced-search-analytics.js
+++ b/dist/tools/advanced-search-analytics.js
@@ -2,7 +2,8 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.advancedSearchAnalytics = advancedSearchAnalytics;
 const analytics_js_1 = require("../analytics.js");
-async function advancedSearchAnalytics(days = 28, dimensions = ["query"], filters = [], rowLimit = 100, orderBy = "clicks", orderDirection = "descending", siteUrl) {
+async function advancedSearchAnalytics(days = 28, dimensions = ["query"], filters = [], rowLimit = 100, orderBy = "clicks", orderDirection = "descending", siteUrl, searchType = "web") {
+    (0, analytics_js_1.assertValidDimensions)(searchType, dimensions);
     const { startDate, endDate } = (0, analytics_js_1.getDateRange)(days);
     // Build dimension filter groups from user-provided filters
     const dimensionFilterGroups = filters.length > 0
@@ -18,6 +19,7 @@ async function advancedSearchAnalytics(days = 28, dimensions = ["query"], filter
         startDate,
         endDate,
         dimensions,
+        searchType,
         dimensionFilterGroups,
     }, siteUrl);
     // Sort

--- a/dist/tools/cannibalization-check.d.ts
+++ b/dist/tools/cannibalization-check.d.ts
@@ -1,3 +1,4 @@
+import { SearchType } from "../analytics.js";
 interface CannibalizationIssue {
     query: string;
     totalImpressions: number;
@@ -8,5 +9,5 @@ interface CannibalizationIssue {
         position: number;
     }>;
 }
-export declare function cannibalizationCheck(days?: number, minImpressions?: number): Promise<CannibalizationIssue[]>;
+export declare function cannibalizationCheck(days?: number, minImpressions?: number, searchType?: SearchType): Promise<CannibalizationIssue[]>;
 export {};

--- a/dist/tools/cannibalization-check.js
+++ b/dist/tools/cannibalization-check.js
@@ -2,12 +2,14 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.cannibalizationCheck = cannibalizationCheck;
 const analytics_js_1 = require("../analytics.js");
-async function cannibalizationCheck(days = 28, minImpressions = 50) {
+async function cannibalizationCheck(days = 28, minImpressions = 50, searchType = "web") {
+    (0, analytics_js_1.assertValidDimensions)(searchType, ["query", "page"]);
     const { startDate, endDate } = (0, analytics_js_1.getDateRange)(days);
     const rows = await (0, analytics_js_1.fetchAllRows)({
         startDate,
         endDate,
         dimensions: ["query", "page"],
+        searchType,
     });
     // Group by query
     const queryMap = new Map();

--- a/dist/tools/check-alerts.d.ts
+++ b/dist/tools/check-alerts.d.ts
@@ -1,3 +1,4 @@
+import { SearchType } from "../analytics.js";
 interface Alert {
     severity: "critical" | "warning" | "info";
     type: "position_drop" | "ctr_drop" | "click_drop" | "disappeared";
@@ -26,5 +27,5 @@ interface AlertResult {
         clickDrop: number;
     };
 }
-export declare function checkAlerts(days?: number, positionDropThreshold?: number, ctrDropThreshold?: number, clickDropThreshold?: number): Promise<AlertResult>;
+export declare function checkAlerts(days?: number, positionDropThreshold?: number, ctrDropThreshold?: number, clickDropThreshold?: number, searchType?: SearchType): Promise<AlertResult>;
 export {};

--- a/dist/tools/check-alerts.js
+++ b/dist/tools/check-alerts.js
@@ -2,13 +2,14 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.checkAlerts = checkAlerts;
 const analytics_js_1 = require("../analytics.js");
-async function checkAlerts(days = 7, positionDropThreshold = 20, ctrDropThreshold = 50, clickDropThreshold = 30) {
+async function checkAlerts(days = 7, positionDropThreshold = 20, ctrDropThreshold = 50, clickDropThreshold = 30, searchType = "web") {
+    (0, analytics_js_1.assertValidDimensions)(searchType, ["query", "page"]);
     const current = (0, analytics_js_1.getDateRange)(days);
     const prior = (0, analytics_js_1.getPriorDateRange)(days);
     // Fetch query+page level data for both periods
     const [currentRows, priorRows] = await Promise.all([
-        (0, analytics_js_1.fetchAllRows)({ startDate: current.startDate, endDate: current.endDate, dimensions: ["query", "page"] }),
-        (0, analytics_js_1.fetchAllRows)({ startDate: prior.startDate, endDate: prior.endDate, dimensions: ["query", "page"] }),
+        (0, analytics_js_1.fetchAllRows)({ startDate: current.startDate, endDate: current.endDate, dimensions: ["query", "page"], searchType }),
+        (0, analytics_js_1.fetchAllRows)({ startDate: prior.startDate, endDate: prior.endDate, dimensions: ["query", "page"], searchType }),
     ]);
     // Build prior period lookup: key = "query|||page"
     const priorMap = new Map();

--- a/dist/tools/content-decay.d.ts
+++ b/dist/tools/content-decay.d.ts
@@ -1,3 +1,4 @@
+import { SearchType } from "../analytics.js";
 interface DecayingPage {
     page: string;
     period1Clicks: number;
@@ -9,5 +10,5 @@ interface DecayingPage {
     period3Position: number;
     positionTrend: string;
 }
-export declare function contentDecay(): Promise<DecayingPage[]>;
+export declare function contentDecay(searchType?: SearchType): Promise<DecayingPage[]>;
 export {};

--- a/dist/tools/content-decay.d.ts
+++ b/dist/tools/content-decay.d.ts
@@ -10,5 +10,5 @@ interface DecayingPage {
     period3Position: number;
     positionTrend: string;
 }
-export declare function contentDecay(searchType?: SearchType): Promise<DecayingPage[]>;
+export declare function contentDecay(searchType?: SearchType, device?: string, country?: string): Promise<DecayingPage[]>;
 export {};

--- a/dist/tools/content-decay.js
+++ b/dist/tools/content-decay.js
@@ -5,7 +5,8 @@ const analytics_js_1 = require("../analytics.js");
 function formatDate(date) {
     return date.toISOString().split("T")[0];
 }
-async function contentDecay() {
+async function contentDecay(searchType = "web") {
+    (0, analytics_js_1.assertValidDimensions)(searchType, ["page"]);
     const now = new Date();
     now.setDate(now.getDate() - 1); // yesterday
     // Period 1: 0-30 days ago (most recent)
@@ -23,9 +24,9 @@ async function contentDecay() {
     const p3Start = new Date(p3End);
     p3Start.setDate(p3Start.getDate() - 29);
     const [rows1, rows2, rows3] = await Promise.all([
-        (0, analytics_js_1.fetchAllRows)({ startDate: formatDate(p1Start), endDate: formatDate(p1End), dimensions: ["page"] }),
-        (0, analytics_js_1.fetchAllRows)({ startDate: formatDate(p2Start), endDate: formatDate(p2End), dimensions: ["page"] }),
-        (0, analytics_js_1.fetchAllRows)({ startDate: formatDate(p3Start), endDate: formatDate(p3End), dimensions: ["page"] }),
+        (0, analytics_js_1.fetchAllRows)({ startDate: formatDate(p1Start), endDate: formatDate(p1End), dimensions: ["page"], searchType }),
+        (0, analytics_js_1.fetchAllRows)({ startDate: formatDate(p2Start), endDate: formatDate(p2End), dimensions: ["page"], searchType }),
+        (0, analytics_js_1.fetchAllRows)({ startDate: formatDate(p3Start), endDate: formatDate(p3End), dimensions: ["page"], searchType }),
     ]);
     const toMap = (rows) => {
         const map = new Map();

--- a/dist/tools/content-decay.js
+++ b/dist/tools/content-decay.js
@@ -5,8 +5,10 @@ const analytics_js_1 = require("../analytics.js");
 function formatDate(date) {
     return date.toISOString().split("T")[0];
 }
-async function contentDecay(searchType = "web") {
+async function contentDecay(searchType = "web", device, country) {
     (0, analytics_js_1.assertValidDimensions)(searchType, ["page"]);
+    const extra = (0, analytics_js_1.deviceCountryFilters)(device, country, searchType);
+    const dimensionFilterGroups = extra.length ? [{ filters: extra }] : undefined;
     const now = new Date();
     now.setDate(now.getDate() - 1); // yesterday
     // Period 1: 0-30 days ago (most recent)
@@ -24,9 +26,9 @@ async function contentDecay(searchType = "web") {
     const p3Start = new Date(p3End);
     p3Start.setDate(p3Start.getDate() - 29);
     const [rows1, rows2, rows3] = await Promise.all([
-        (0, analytics_js_1.fetchAllRows)({ startDate: formatDate(p1Start), endDate: formatDate(p1End), dimensions: ["page"], searchType }),
-        (0, analytics_js_1.fetchAllRows)({ startDate: formatDate(p2Start), endDate: formatDate(p2End), dimensions: ["page"], searchType }),
-        (0, analytics_js_1.fetchAllRows)({ startDate: formatDate(p3Start), endDate: formatDate(p3End), dimensions: ["page"], searchType }),
+        (0, analytics_js_1.fetchAllRows)({ startDate: formatDate(p1Start), endDate: formatDate(p1End), dimensions: ["page"], searchType, dimensionFilterGroups }),
+        (0, analytics_js_1.fetchAllRows)({ startDate: formatDate(p2Start), endDate: formatDate(p2End), dimensions: ["page"], searchType, dimensionFilterGroups }),
+        (0, analytics_js_1.fetchAllRows)({ startDate: formatDate(p3Start), endDate: formatDate(p3End), dimensions: ["page"], searchType, dimensionFilterGroups }),
     ]);
     const toMap = (rows) => {
         const map = new Map();

--- a/dist/tools/content-gaps.d.ts
+++ b/dist/tools/content-gaps.d.ts
@@ -1,8 +1,9 @@
+import { SearchType } from "../analytics.js";
 interface ContentGap {
     query: string;
     impressions: number;
     clicks: number;
     position: number;
 }
-export declare function contentGaps(days?: number, minImpressions?: number, minPosition?: number): Promise<ContentGap[]>;
+export declare function contentGaps(days?: number, minImpressions?: number, minPosition?: number, searchType?: SearchType): Promise<ContentGap[]>;
 export {};

--- a/dist/tools/content-gaps.js
+++ b/dist/tools/content-gaps.js
@@ -2,12 +2,14 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.contentGaps = contentGaps;
 const analytics_js_1 = require("../analytics.js");
-async function contentGaps(days = 90, minImpressions = 50, minPosition = 20) {
+async function contentGaps(days = 90, minImpressions = 50, minPosition = 20, searchType = "web") {
+    (0, analytics_js_1.assertValidDimensions)(searchType, ["query"]);
     const { startDate, endDate } = (0, analytics_js_1.getDateRange)(days);
     const rows = await (0, analytics_js_1.fetchAllRows)({
         startDate,
         endDate,
         dimensions: ["query"],
+        searchType,
     });
     const gaps = [];
     for (const row of rows) {

--- a/dist/tools/ctr-opportunities.d.ts
+++ b/dist/tools/ctr-opportunities.d.ts
@@ -1,3 +1,4 @@
+import { SearchType } from "../analytics.js";
 interface CtrOpportunity {
     page: string;
     clicks: number;
@@ -8,5 +9,5 @@ interface CtrOpportunity {
     ctrGap: number;
     potentialExtraClicks: number;
 }
-export declare function ctrOpportunities(days?: number, minImpressions?: number): Promise<CtrOpportunity[]>;
+export declare function ctrOpportunities(days?: number, minImpressions?: number, searchType?: SearchType): Promise<CtrOpportunity[]>;
 export {};

--- a/dist/tools/ctr-opportunities.d.ts
+++ b/dist/tools/ctr-opportunities.d.ts
@@ -9,5 +9,5 @@ interface CtrOpportunity {
     ctrGap: number;
     potentialExtraClicks: number;
 }
-export declare function ctrOpportunities(days?: number, minImpressions?: number, searchType?: SearchType): Promise<CtrOpportunity[]>;
+export declare function ctrOpportunities(days?: number, minImpressions?: number, searchType?: SearchType, device?: string, country?: string): Promise<CtrOpportunity[]>;
 export {};

--- a/dist/tools/ctr-opportunities.js
+++ b/dist/tools/ctr-opportunities.js
@@ -10,12 +10,14 @@ function expectedCtrAtPosition(pos) {
         return EXPECTED_CTR[Math.floor(pos) - 1];
     return Math.max(0.005, 0.025 - (pos - 10) * 0.002);
 }
-async function ctrOpportunities(days = 28, minImpressions = 500) {
+async function ctrOpportunities(days = 28, minImpressions = 500, searchType = "web") {
+    (0, analytics_js_1.assertValidDimensions)(searchType, ["page"]);
     const { startDate, endDate } = (0, analytics_js_1.getDateRange)(days);
     const rows = await (0, analytics_js_1.fetchAllRows)({
         startDate,
         endDate,
         dimensions: ["page"],
+        searchType,
     });
     const opportunities = [];
     for (const row of rows) {

--- a/dist/tools/ctr-opportunities.js
+++ b/dist/tools/ctr-opportunities.js
@@ -10,10 +10,13 @@ function expectedCtrAtPosition(pos) {
         return EXPECTED_CTR[Math.floor(pos) - 1];
     return Math.max(0.005, 0.025 - (pos - 10) * 0.002);
 }
-async function ctrOpportunities(days = 28, minImpressions = 500, searchType = "web") {
+async function ctrOpportunities(days = 28, minImpressions = 500, searchType = "web", device, country) {
     (0, analytics_js_1.assertValidDimensions)(searchType, ["page"]);
     const { startDate, endDate } = (0, analytics_js_1.getDateRange)(days);
+    const extra = (0, analytics_js_1.deviceCountryFilters)(device, country, searchType);
+    const dimensionFilterGroups = extra.length ? [{ filters: extra }] : undefined;
     const rows = await (0, analytics_js_1.fetchAllRows)({
+        dimensionFilterGroups,
         startDate,
         endDate,
         dimensions: ["page"],

--- a/dist/tools/ctr-vs-benchmark.d.ts
+++ b/dist/tools/ctr-vs-benchmark.d.ts
@@ -1,3 +1,4 @@
+import { SearchType } from "../analytics.js";
 interface CtrBenchmarkResult {
     page: string;
     clicks: number;
@@ -8,5 +9,5 @@ interface CtrBenchmarkResult {
     gap: number;
     verdict: string;
 }
-export declare function ctrVsBenchmark(days?: number, minImpressions?: number): Promise<CtrBenchmarkResult[]>;
+export declare function ctrVsBenchmark(days?: number, minImpressions?: number, searchType?: SearchType): Promise<CtrBenchmarkResult[]>;
 export {};

--- a/dist/tools/ctr-vs-benchmark.js
+++ b/dist/tools/ctr-vs-benchmark.js
@@ -10,12 +10,14 @@ function benchmarkCtr(pos) {
         return BENCHMARK_CTR[Math.floor(pos) - 1];
     return Math.max(0.005, 0.025 - (pos - 10) * 0.002);
 }
-async function ctrVsBenchmark(days = 28, minImpressions = 200) {
+async function ctrVsBenchmark(days = 28, minImpressions = 200, searchType = "web") {
+    (0, analytics_js_1.assertValidDimensions)(searchType, ["page"]);
     const { startDate, endDate } = (0, analytics_js_1.getDateRange)(days);
     const rows = await (0, analytics_js_1.fetchAllRows)({
         startDate,
         endDate,
         dimensions: ["page"],
+        searchType,
     });
     const results = [];
     for (const row of rows) {

--- a/dist/tools/discover-analysis.d.ts
+++ b/dist/tools/discover-analysis.d.ts
@@ -1,0 +1,43 @@
+interface PeriodTotals {
+    clicks: number;
+    impressions: number;
+    ctr: number;
+}
+interface DiscoverPage {
+    page: string;
+    clicks: number;
+    impressions: number;
+    ctr: number;
+}
+interface DiscoverAnalysisResult {
+    surface: "discover";
+    period: {
+        startDate: string;
+        endDate: string;
+    };
+    totals: PeriodTotals;
+    change: {
+        clicksPercent: number;
+        impressionsPercent: number;
+    };
+    topPages: DiscoverPage[];
+    byCountry: Array<{
+        country: string;
+        clicks: number;
+        impressions: number;
+        ctr: number;
+    }>;
+    dailyTrend: Array<{
+        date: string;
+        clicks: number;
+        impressions: number;
+    }>;
+    note: string;
+}
+/**
+ * Isolated Google Discover performance. Discover is NOT query-based, so the API
+ * only supports page / country / date dimensions here. Position/CTR-vs-position
+ * benchmarks from web tools do not apply.
+ */
+export declare function discoverAnalysis(days?: number, rowLimit?: number, siteUrl?: string): Promise<DiscoverAnalysisResult>;
+export {};

--- a/dist/tools/discover-analysis.js
+++ b/dist/tools/discover-analysis.js
@@ -1,0 +1,73 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.discoverAnalysis = discoverAnalysis;
+const analytics_js_1 = require("../analytics.js");
+function totals(rows) {
+    let clicks = 0;
+    let impressions = 0;
+    for (const r of rows) {
+        clicks += r.clicks;
+        impressions += r.impressions;
+    }
+    return {
+        clicks,
+        impressions,
+        ctr: impressions > 0 ? Math.round((clicks / impressions) * 10000) / 100 : 0,
+    };
+}
+function pct(curr, prior) {
+    return prior > 0 ? Math.round(((curr - prior) / prior) * 10000) / 100 : 0;
+}
+/**
+ * Isolated Google Discover performance. Discover is NOT query-based, so the API
+ * only supports page / country / date dimensions here. Position/CTR-vs-position
+ * benchmarks from web tools do not apply.
+ */
+async function discoverAnalysis(days = 28, rowLimit = 50, siteUrl) {
+    const current = (0, analytics_js_1.getDateRange)(days);
+    const prior = (0, analytics_js_1.getPriorDateRange)(days);
+    (0, analytics_js_1.assertValidDimensions)("discover", ["page"]);
+    const [pageRows, priorPageRows, countryRows, dateRows] = await Promise.all([
+        (0, analytics_js_1.fetchAllRows)({ startDate: current.startDate, endDate: current.endDate, dimensions: ["page"], searchType: "discover" }, siteUrl),
+        (0, analytics_js_1.fetchAllRows)({ startDate: prior.startDate, endDate: prior.endDate, dimensions: ["page"], searchType: "discover" }, siteUrl),
+        (0, analytics_js_1.fetchAllRows)({ startDate: current.startDate, endDate: current.endDate, dimensions: ["country"], searchType: "discover" }, siteUrl),
+        (0, analytics_js_1.fetchAllRows)({ startDate: current.startDate, endDate: current.endDate, dimensions: ["date"], searchType: "discover" }, siteUrl),
+    ]);
+    const curTotals = totals(pageRows);
+    const priorTotals = totals(priorPageRows);
+    const topPages = pageRows
+        .sort((a, b) => b.clicks - a.clicks)
+        .slice(0, Math.min(rowLimit, 200))
+        .map((r) => ({
+        page: r.keys[0],
+        clicks: r.clicks,
+        impressions: r.impressions,
+        ctr: Math.round(r.ctr * 10000) / 100,
+    }));
+    const byCountry = countryRows
+        .sort((a, b) => b.clicks - a.clicks)
+        .slice(0, 15)
+        .map((r) => ({
+        country: r.keys[0],
+        clicks: r.clicks,
+        impressions: r.impressions,
+        ctr: Math.round(r.ctr * 10000) / 100,
+    }));
+    const dailyTrend = dateRows
+        .sort((a, b) => a.keys[0].localeCompare(b.keys[0]))
+        .map((r) => ({ date: r.keys[0], clicks: r.clicks, impressions: r.impressions }));
+    return {
+        surface: "discover",
+        period: current,
+        totals: curTotals,
+        change: {
+            clicksPercent: pct(curTotals.clicks, priorTotals.clicks),
+            impressionsPercent: pct(curTotals.impressions, priorTotals.impressions),
+        },
+        topPages,
+        byCountry,
+        dailyTrend,
+        note: "Google Discover is feed-based, not query-based. There are no query-level rows " +
+            "and average position is not meaningful here. Optimise on title, hero image and freshness.",
+    };
+}

--- a/dist/tools/image-analysis.d.ts
+++ b/dist/tools/image-analysis.d.ts
@@ -1,0 +1,40 @@
+interface PeriodTotals {
+    clicks: number;
+    impressions: number;
+    ctr: number;
+    position: number;
+}
+interface ImageAnalysisResult {
+    surface: "image";
+    period: {
+        startDate: string;
+        endDate: string;
+    };
+    totals: PeriodTotals;
+    change: {
+        clicksPercent: number;
+        impressionsPercent: number;
+        position: number;
+    };
+    topQueries: Array<{
+        query: string;
+        clicks: number;
+        impressions: number;
+        ctr: number;
+        position: number;
+    }>;
+    topPages: Array<{
+        page: string;
+        clicks: number;
+        impressions: number;
+        ctr: number;
+        position: number;
+    }>;
+    note: string;
+}
+/**
+ * Isolated Google Image search performance. Image search supports the same
+ * dimensions as web (query, page, country, device, date).
+ */
+export declare function imageAnalysis(days?: number, rowLimit?: number, siteUrl?: string): Promise<ImageAnalysisResult>;
+export {};

--- a/dist/tools/image-analysis.js
+++ b/dist/tools/image-analysis.js
@@ -1,0 +1,75 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.imageAnalysis = imageAnalysis;
+const analytics_js_1 = require("../analytics.js");
+function summarise(rows) {
+    let clicks = 0;
+    let impressions = 0;
+    let posSum = 0;
+    let posCount = 0;
+    for (const r of rows) {
+        clicks += r.clicks;
+        impressions += r.impressions;
+        posSum += r.position;
+        posCount++;
+    }
+    return {
+        clicks,
+        impressions,
+        ctr: impressions > 0 ? Math.round((clicks / impressions) * 10000) / 100 : 0,
+        position: posCount > 0 ? Math.round((posSum / posCount) * 10) / 10 : 0,
+    };
+}
+function pct(curr, prior) {
+    return prior > 0 ? Math.round(((curr - prior) / prior) * 10000) / 100 : 0;
+}
+/**
+ * Isolated Google Image search performance. Image search supports the same
+ * dimensions as web (query, page, country, device, date).
+ */
+async function imageAnalysis(days = 28, rowLimit = 50, siteUrl) {
+    const current = (0, analytics_js_1.getDateRange)(days);
+    const prior = (0, analytics_js_1.getPriorDateRange)(days);
+    const [queryRows, pageRows, priorRows] = await Promise.all([
+        (0, analytics_js_1.fetchAllRows)({ startDate: current.startDate, endDate: current.endDate, dimensions: ["query"], searchType: "image" }, siteUrl),
+        (0, analytics_js_1.fetchAllRows)({ startDate: current.startDate, endDate: current.endDate, dimensions: ["page"], searchType: "image" }, siteUrl),
+        (0, analytics_js_1.fetchAllRows)({ startDate: prior.startDate, endDate: prior.endDate, dimensions: ["date"], searchType: "image" }, siteUrl),
+    ]);
+    const dateRowsCurrent = await (0, analytics_js_1.fetchAllRows)({ startDate: current.startDate, endDate: current.endDate, dimensions: ["date"], searchType: "image" }, siteUrl);
+    const curTotals = summarise(dateRowsCurrent);
+    const priorTotals = summarise(priorRows);
+    const topQueries = queryRows
+        .sort((a, b) => b.clicks - a.clicks)
+        .slice(0, Math.min(rowLimit, 200))
+        .map((r) => ({
+        query: r.keys[0],
+        clicks: r.clicks,
+        impressions: r.impressions,
+        ctr: Math.round(r.ctr * 10000) / 100,
+        position: Math.round(r.position * 10) / 10,
+    }));
+    const topPages = pageRows
+        .sort((a, b) => b.clicks - a.clicks)
+        .slice(0, Math.min(rowLimit, 200))
+        .map((r) => ({
+        page: r.keys[0],
+        clicks: r.clicks,
+        impressions: r.impressions,
+        ctr: Math.round(r.ctr * 10000) / 100,
+        position: Math.round(r.position * 10) / 10,
+    }));
+    return {
+        surface: "image",
+        period: current,
+        totals: curTotals,
+        change: {
+            clicksPercent: pct(curTotals.clicks, priorTotals.clicks),
+            impressionsPercent: pct(curTotals.impressions, priorTotals.impressions),
+            position: Math.round((curTotals.position - priorTotals.position) * 10) / 10,
+        },
+        topQueries,
+        topPages,
+        note: "Image search data only. Optimise on filename, alt text, surrounding context, " +
+            "image dimensions and structured data (ImageObject).",
+    };
+}

--- a/dist/tools/query-count.d.ts
+++ b/dist/tools/query-count.d.ts
@@ -1,13 +1,19 @@
 import { SearchType } from "../analytics.js";
 /**
- * Query counting: how many distinct queries a site (and each page) is visible
- * for, split by position group.
+ * Query counting: how many distinct queries a property, a section or a single
+ * URL is visible for - split by position group, optionally as a time series.
  *
- * The number GSC hands back is a FLOOR, not the truth: queries below Google's
- * privacy threshold never appear as rows, so their clicks show up in the site
- * total but in no query row. We therefore also report that gap explicitly
- * instead of pretending the query table is complete.
+ * The count GSC hands back is a FLOOR, not the truth: queries below Google's
+ * privacy threshold never appear as rows, so their clicks land in the totals
+ * but in no query row. That gap is reported explicitly instead of leaving the
+ * query table to be mistaken for the complete keyword set.
+ *
+ * Time series buckets are fetched one request per bucket. That is deliberate:
+ * the API de-duplicates queries within the requested range, so a per-bucket
+ * request yields an exact distinct count without holding every query string
+ * of every day in memory.
  */
+export type Granularity = "none" | "day" | "week" | "month";
 interface PositionGroupCount {
     group: string;
     queries: number;
@@ -21,11 +27,25 @@ interface PageQueryCount {
     clicks: number;
     impressions: number;
 }
+interface Bucket {
+    startDate: string;
+    endDate: string;
+    visibleQueries: number;
+    clicks: number;
+    impressions: number;
+}
 interface QueryCountResult {
     period: {
         startDate: string;
         endDate: string;
         days: number;
+    };
+    scope: {
+        url: string | null;
+        urlContains: string | null;
+        surface: SearchType;
+        minPosition: number | null;
+        maxPosition: number | null;
     };
     totals: {
         visibleQueries: number;
@@ -34,7 +54,13 @@ interface QueryCountResult {
         anonymizedClicks: number;
         anonymizedClicksShare: number;
     };
+    filtered: {
+        visibleQueries: number;
+        clicks: number;
+        impressions: number;
+    } | null;
     byPositionGroup: PositionGroupCount[];
+    timeSeries: Bucket[] | null;
     previousPeriod: {
         startDate: string;
         endDate: string;
@@ -44,5 +70,5 @@ interface QueryCountResult {
     } | null;
     topPagesByQueryCount: PageQueryCount[] | null;
 }
-export declare function queryCount(days?: number, comparePrevious?: boolean, includePages?: boolean, topPages?: number, searchType?: SearchType): Promise<QueryCountResult>;
+export declare function queryCount(days?: number, comparePrevious?: boolean, includePages?: boolean, topPages?: number, surface?: SearchType, url?: string, urlContains?: string, granularity?: Granularity, minPosition?: number, maxPosition?: number): Promise<QueryCountResult>;
 export {};

--- a/dist/tools/query-count.d.ts
+++ b/dist/tools/query-count.d.ts
@@ -46,6 +46,8 @@ interface QueryCountResult {
         surface: SearchType;
         minPosition: number | null;
         maxPosition: number | null;
+        device: string | null;
+        country: string | null;
     };
     totals: {
         visibleQueries: number;
@@ -69,6 +71,7 @@ interface QueryCountResult {
         changePercent: number;
     } | null;
     topPagesByQueryCount: PageQueryCount[] | null;
+    comparabilityWarning: string | null;
 }
-export declare function queryCount(days?: number, comparePrevious?: boolean, includePages?: boolean, topPages?: number, surface?: SearchType, url?: string, urlContains?: string, granularity?: Granularity, minPosition?: number, maxPosition?: number): Promise<QueryCountResult>;
+export declare function queryCount(days?: number, comparePrevious?: boolean, includePages?: boolean, topPages?: number, surface?: SearchType, url?: string, urlContains?: string, granularity?: Granularity, minPosition?: number, maxPosition?: number, device?: string, country?: string): Promise<QueryCountResult>;
 export {};

--- a/dist/tools/query-count.d.ts
+++ b/dist/tools/query-count.d.ts
@@ -1,0 +1,48 @@
+import { SearchType } from "../analytics.js";
+/**
+ * Query counting: how many distinct queries a site (and each page) is visible
+ * for, split by position group.
+ *
+ * The number GSC hands back is a FLOOR, not the truth: queries below Google's
+ * privacy threshold never appear as rows, so their clicks show up in the site
+ * total but in no query row. We therefore also report that gap explicitly
+ * instead of pretending the query table is complete.
+ */
+interface PositionGroupCount {
+    group: string;
+    queries: number;
+    clicks: number;
+    impressions: number;
+    queryShare: number;
+}
+interface PageQueryCount {
+    page: string;
+    queries: number;
+    clicks: number;
+    impressions: number;
+}
+interface QueryCountResult {
+    period: {
+        startDate: string;
+        endDate: string;
+        days: number;
+    };
+    totals: {
+        visibleQueries: number;
+        clicksFromVisibleQueries: number;
+        totalClicks: number;
+        anonymizedClicks: number;
+        anonymizedClicksShare: number;
+    };
+    byPositionGroup: PositionGroupCount[];
+    previousPeriod: {
+        startDate: string;
+        endDate: string;
+        visibleQueries: number;
+        change: number;
+        changePercent: number;
+    } | null;
+    topPagesByQueryCount: PageQueryCount[] | null;
+}
+export declare function queryCount(days?: number, comparePrevious?: boolean, includePages?: boolean, topPages?: number, searchType?: SearchType): Promise<QueryCountResult>;
+export {};

--- a/dist/tools/query-count.js
+++ b/dist/tools/query-count.js
@@ -1,0 +1,113 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.queryCount = queryCount;
+const analytics_js_1 = require("../analytics.js");
+const POSITION_GROUPS = ["1-3", "4-10", "11-20", "21-50", "51+"];
+function positionGroup(position) {
+    if (position <= 3)
+        return "1-3";
+    if (position <= 10)
+        return "4-10";
+    if (position <= 20)
+        return "11-20";
+    if (position <= 50)
+        return "21-50";
+    return "51+";
+}
+async function queryCount(days = 28, comparePrevious = true, includePages = false, topPages = 25, searchType = "web") {
+    (0, analytics_js_1.assertValidDimensions)(searchType, ["query"]);
+    const { startDate, endDate } = (0, analytics_js_1.getDateRange)(days);
+    const queryRows = await (0, analytics_js_1.fetchAllRows)({
+        startDate,
+        endDate,
+        dimensions: ["query"],
+        searchType,
+    });
+    // Site totals without the query dimension. Grouping by date keeps the request
+    // small while still summing to the same figure the GSC dashboard shows.
+    const dateRows = await (0, analytics_js_1.fetchAllRows)({
+        startDate,
+        endDate,
+        dimensions: ["date"],
+        searchType,
+    });
+    const clicksFromVisibleQueries = queryRows.reduce((sum, r) => sum + r.clicks, 0);
+    const totalClicks = dateRows.reduce((sum, r) => sum + r.clicks, 0);
+    const anonymizedClicks = Math.max(0, totalClicks - clicksFromVisibleQueries);
+    const buckets = new Map();
+    for (const group of POSITION_GROUPS) {
+        buckets.set(group, { queries: 0, clicks: 0, impressions: 0 });
+    }
+    for (const row of queryRows) {
+        const bucket = buckets.get(positionGroup(row.position));
+        bucket.queries += 1;
+        bucket.clicks += row.clicks;
+        bucket.impressions += row.impressions;
+    }
+    const visibleQueries = queryRows.length;
+    const byPositionGroup = POSITION_GROUPS.map((group) => {
+        const bucket = buckets.get(group);
+        return {
+            group,
+            queries: bucket.queries,
+            clicks: bucket.clicks,
+            impressions: bucket.impressions,
+            queryShare: visibleQueries > 0 ? Math.round((bucket.queries / visibleQueries) * 10000) / 100 : 0,
+        };
+    });
+    let previousPeriod = null;
+    if (comparePrevious) {
+        const prior = (0, analytics_js_1.getPriorDateRange)(days);
+        const priorRows = await (0, analytics_js_1.fetchAllRows)({
+            startDate: prior.startDate,
+            endDate: prior.endDate,
+            dimensions: ["query"],
+            searchType,
+        });
+        const change = visibleQueries - priorRows.length;
+        previousPeriod = {
+            startDate: prior.startDate,
+            endDate: prior.endDate,
+            visibleQueries: priorRows.length,
+            change,
+            changePercent: priorRows.length > 0 ? Math.round((change / priorRows.length) * 10000) / 100 : 0,
+        };
+    }
+    let topPagesByQueryCount = null;
+    if (includePages) {
+        (0, analytics_js_1.assertValidDimensions)(searchType, ["page", "query"]);
+        const pageQueryRows = await (0, analytics_js_1.fetchAllRows)({
+            startDate,
+            endDate,
+            dimensions: ["page", "query"],
+            searchType,
+            maxRows: 100000,
+        });
+        const pages = new Map();
+        for (const row of pageQueryRows) {
+            const page = row.keys[0];
+            const entry = pages.get(page) || { queries: 0, clicks: 0, impressions: 0 };
+            entry.queries += 1;
+            entry.clicks += row.clicks;
+            entry.impressions += row.impressions;
+            pages.set(page, entry);
+        }
+        topPagesByQueryCount = [...pages.entries()]
+            .map(([page, entry]) => ({ page, ...entry }))
+            .sort((a, b) => b.queries - a.queries)
+            .slice(0, topPages);
+    }
+    return {
+        period: { startDate, endDate, days },
+        totals: {
+            visibleQueries,
+            clicksFromVisibleQueries,
+            totalClicks,
+            anonymizedClicks,
+            anonymizedClicksShare: totalClicks > 0 ? Math.round((anonymizedClicks / totalClicks) * 10000) / 100 : 0,
+        },
+        byPositionGroup,
+        previousPeriod,
+        topPagesByQueryCount,
+    };
+}

--- a/dist/tools/query-count.js
+++ b/dist/tools/query-count.js
@@ -14,77 +14,145 @@ function positionGroup(position) {
         return "21-50";
     return "51+";
 }
-async function queryCount(days = 28, comparePrevious = true, includePages = false, topPages = 25, searchType = "web") {
-    (0, analytics_js_1.assertValidDimensions)(searchType, ["query"]);
+function parseISO(date) {
+    const [y, m, d] = date.split("-").map(Number);
+    return new Date(Date.UTC(y, m - 1, d));
+}
+function toISO(date) {
+    return date.toISOString().split("T")[0];
+}
+/** Splits a date range into day, ISO-week (Mon-Sun) or calendar-month buckets. */
+function buildBuckets(startDate, endDate, granularity) {
+    const end = parseISO(endDate);
+    const out = [];
+    let cursor = parseISO(startDate);
+    while (cursor <= end) {
+        let bucketEnd;
+        if (granularity === "day") {
+            bucketEnd = new Date(cursor);
+        }
+        else if (granularity === "week") {
+            const mondayOffset = (cursor.getUTCDay() + 6) % 7; // 0 = Monday
+            bucketEnd = new Date(cursor);
+            bucketEnd.setUTCDate(bucketEnd.getUTCDate() + (6 - mondayOffset));
+        }
+        else {
+            bucketEnd = new Date(Date.UTC(cursor.getUTCFullYear(), cursor.getUTCMonth() + 1, 0));
+        }
+        if (bucketEnd > end)
+            bucketEnd = new Date(end);
+        out.push({ startDate: toISO(cursor), endDate: toISO(bucketEnd) });
+        cursor = new Date(bucketEnd);
+        cursor.setUTCDate(cursor.getUTCDate() + 1);
+    }
+    return out;
+}
+async function queryCount(days = 28, comparePrevious = true, includePages = false, topPages = 25, surface = "web", url, urlContains, granularity = "none", minPosition, maxPosition) {
+    (0, analytics_js_1.assertValidDimensions)(surface, ["query"]);
+    if (granularity === "day" && days > 90) {
+        throw new Error(`granularity "day" over ${days} days would need ${days}+ API requests. ` +
+            `Use "week" or "month" for ranges beyond 90 days.`);
+    }
     const { startDate, endDate } = (0, analytics_js_1.getDateRange)(days);
-    const queryRows = await (0, analytics_js_1.fetchAllRows)({
-        startDate,
-        endDate,
-        dimensions: ["query"],
-        searchType,
+    const pageFilters = [];
+    if (url)
+        pageFilters.push({ dimension: "page", operator: "equals", expression: url });
+    if (urlContains)
+        pageFilters.push({ dimension: "page", operator: "contains", expression: urlContains });
+    const dimensionFilterGroups = pageFilters.length ? [{ filters: pageFilters }] : undefined;
+    const scoped = (params) => ({
+        ...params,
+        dimensionFilterGroups,
     });
-    // Site totals without the query dimension. Grouping by date keeps the request
-    // small while still summing to the same figure the GSC dashboard shows.
-    const dateRows = await (0, analytics_js_1.fetchAllRows)({
-        startDate,
-        endDate,
-        dimensions: ["date"],
-        searchType,
-    });
+    const queryRows = await (0, analytics_js_1.fetchAllRows)(scoped({ startDate, endDate, dimensions: ["query"], searchType: surface }));
+    // Totals without the query dimension: same scope, but including the clicks
+    // that no visible query row accounts for.
+    const dateRows = await (0, analytics_js_1.fetchAllRows)(scoped({ startDate, endDate, dimensions: ["date"], searchType: surface }));
     const clicksFromVisibleQueries = queryRows.reduce((sum, r) => sum + r.clicks, 0);
     const totalClicks = dateRows.reduce((sum, r) => sum + r.clicks, 0);
     const anonymizedClicks = Math.max(0, totalClicks - clicksFromVisibleQueries);
-    const buckets = new Map();
+    // The position filter narrows what gets counted, but never the gap above:
+    // that one only makes sense against the unfiltered scope.
+    const inPositionFilter = (position) => (minPosition === undefined || position >= minPosition) &&
+        (maxPosition === undefined || position <= maxPosition);
+    const hasPositionFilter = minPosition !== undefined || maxPosition !== undefined;
+    const countedRows = hasPositionFilter
+        ? queryRows.filter((r) => inPositionFilter(r.position))
+        : queryRows;
+    const groups = new Map();
     for (const group of POSITION_GROUPS) {
-        buckets.set(group, { queries: 0, clicks: 0, impressions: 0 });
+        groups.set(group, { queries: 0, clicks: 0, impressions: 0 });
     }
-    for (const row of queryRows) {
-        const bucket = buckets.get(positionGroup(row.position));
-        bucket.queries += 1;
-        bucket.clicks += row.clicks;
-        bucket.impressions += row.impressions;
+    for (const row of countedRows) {
+        const entry = groups.get(positionGroup(row.position));
+        entry.queries += 1;
+        entry.clicks += row.clicks;
+        entry.impressions += row.impressions;
     }
-    const visibleQueries = queryRows.length;
+    const countedTotal = countedRows.length;
     const byPositionGroup = POSITION_GROUPS.map((group) => {
-        const bucket = buckets.get(group);
+        const entry = groups.get(group);
         return {
             group,
-            queries: bucket.queries,
-            clicks: bucket.clicks,
-            impressions: bucket.impressions,
-            queryShare: visibleQueries > 0 ? Math.round((bucket.queries / visibleQueries) * 10000) / 100 : 0,
+            queries: entry.queries,
+            clicks: entry.clicks,
+            impressions: entry.impressions,
+            queryShare: countedTotal > 0 ? Math.round((entry.queries / countedTotal) * 10000) / 100 : 0,
         };
     });
+    let timeSeries = null;
+    if (granularity !== "none") {
+        timeSeries = [];
+        for (const bucket of buildBuckets(startDate, endDate, granularity)) {
+            const rows = await (0, analytics_js_1.fetchAllRows)(scoped({
+                startDate: bucket.startDate,
+                endDate: bucket.endDate,
+                dimensions: ["query"],
+                searchType: surface,
+            }));
+            const counted = hasPositionFilter ? rows.filter((r) => inPositionFilter(r.position)) : rows;
+            timeSeries.push({
+                startDate: bucket.startDate,
+                endDate: bucket.endDate,
+                visibleQueries: counted.length,
+                clicks: counted.reduce((sum, r) => sum + r.clicks, 0),
+                impressions: counted.reduce((sum, r) => sum + r.impressions, 0),
+            });
+        }
+    }
     let previousPeriod = null;
     if (comparePrevious) {
         const prior = (0, analytics_js_1.getPriorDateRange)(days);
-        const priorRows = await (0, analytics_js_1.fetchAllRows)({
+        const priorRows = await (0, analytics_js_1.fetchAllRows)(scoped({
             startDate: prior.startDate,
             endDate: prior.endDate,
             dimensions: ["query"],
-            searchType,
-        });
-        const change = visibleQueries - priorRows.length;
+            searchType: surface,
+        }));
+        const priorCount = (hasPositionFilter ? priorRows.filter((r) => inPositionFilter(r.position)) : priorRows).length;
+        const change = countedTotal - priorCount;
         previousPeriod = {
             startDate: prior.startDate,
             endDate: prior.endDate,
-            visibleQueries: priorRows.length,
+            visibleQueries: priorCount,
             change,
-            changePercent: priorRows.length > 0 ? Math.round((change / priorRows.length) * 10000) / 100 : 0,
+            changePercent: priorCount > 0 ? Math.round((change / priorCount) * 10000) / 100 : 0,
         };
     }
     let topPagesByQueryCount = null;
     if (includePages) {
-        (0, analytics_js_1.assertValidDimensions)(searchType, ["page", "query"]);
-        const pageQueryRows = await (0, analytics_js_1.fetchAllRows)({
+        (0, analytics_js_1.assertValidDimensions)(surface, ["page", "query"]);
+        const pageQueryRows = await (0, analytics_js_1.fetchAllRows)(scoped({
             startDate,
             endDate,
             dimensions: ["page", "query"],
-            searchType,
+            searchType: surface,
             maxRows: 100000,
-        });
+        }));
         const pages = new Map();
         for (const row of pageQueryRows) {
+            if (hasPositionFilter && !inPositionFilter(row.position))
+                continue;
             const page = row.keys[0];
             const entry = pages.get(page) || { queries: 0, clicks: 0, impressions: 0 };
             entry.queries += 1;
@@ -99,14 +167,29 @@ async function queryCount(days = 28, comparePrevious = true, includePages = fals
     }
     return {
         period: { startDate, endDate, days },
+        scope: {
+            url: url ?? null,
+            urlContains: urlContains ?? null,
+            surface,
+            minPosition: minPosition ?? null,
+            maxPosition: maxPosition ?? null,
+        },
         totals: {
-            visibleQueries,
+            visibleQueries: queryRows.length,
             clicksFromVisibleQueries,
             totalClicks,
             anonymizedClicks,
             anonymizedClicksShare: totalClicks > 0 ? Math.round((anonymizedClicks / totalClicks) * 10000) / 100 : 0,
         },
+        filtered: hasPositionFilter
+            ? {
+                visibleQueries: countedTotal,
+                clicks: countedRows.reduce((sum, r) => sum + r.clicks, 0),
+                impressions: countedRows.reduce((sum, r) => sum + r.impressions, 0),
+            }
+            : null,
         byPositionGroup,
+        timeSeries,
         previousPeriod,
         topPagesByQueryCount,
     };

--- a/dist/tools/query-count.js
+++ b/dist/tools/query-count.js
@@ -47,7 +47,7 @@ function buildBuckets(startDate, endDate, granularity) {
     }
     return out;
 }
-async function queryCount(days = 28, comparePrevious = true, includePages = false, topPages = 25, surface = "web", url, urlContains, granularity = "none", minPosition, maxPosition) {
+async function queryCount(days = 28, comparePrevious = true, includePages = false, topPages = 25, surface = "web", url, urlContains, granularity = "none", minPosition, maxPosition, device, country) {
     (0, analytics_js_1.assertValidDimensions)(surface, ["query"]);
     if (granularity === "day" && days > 90) {
         throw new Error(`granularity "day" over ${days} days would need ${days}+ API requests. ` +
@@ -59,6 +59,7 @@ async function queryCount(days = 28, comparePrevious = true, includePages = fals
         pageFilters.push({ dimension: "page", operator: "equals", expression: url });
     if (urlContains)
         pageFilters.push({ dimension: "page", operator: "contains", expression: urlContains });
+    pageFilters.push(...(0, analytics_js_1.deviceCountryFilters)(device, country, surface));
     const dimensionFilterGroups = pageFilters.length ? [{ filters: pageFilters }] : undefined;
     const scoped = (params) => ({
         ...params,
@@ -173,6 +174,8 @@ async function queryCount(days = 28, comparePrevious = true, includePages = fals
             surface,
             minPosition: minPosition ?? null,
             maxPosition: maxPosition ?? null,
+            device: device ? device.toUpperCase() : null,
+            country: country ? country.toLowerCase() : null,
         },
         totals: {
             visibleQueries: queryRows.length,
@@ -192,5 +195,14 @@ async function queryCount(days = 28, comparePrevious = true, includePages = fals
         timeSeries,
         previousPeriod,
         topPagesByQueryCount,
+        // Measured against a live property: the API returns MORE query rows for a
+        // single device slice than for the unfiltered call over the same period
+        // (38,586 unfiltered vs 80,531 for MOBILE alone). Clicks stay consistent,
+        // so the filter itself is fine - the API simply surfaces more queries once
+        // the request is narrowed. Counts are therefore comparable only between
+        // runs with the SAME filter, never between filtered and unfiltered.
+        comparabilityWarning: device || country
+            ? "A device or country filter is active. The API returns more query rows for a narrowed request than for the unfiltered one over the same period, so visibleQueries here is NOT comparable to an unfiltered run or to a run with a different filter - only to runs with this exact filter. Clicks and impressions are unaffected. For counts that stay comparable across slices, use the BigQuery bulk export (gsc_query_count in the BigQuery MCP), which does not truncate."
+            : null,
     };
 }

--- a/dist/tools/quick-wins.d.ts
+++ b/dist/tools/quick-wins.d.ts
@@ -1,3 +1,4 @@
+import { SearchType } from "../analytics.js";
 interface QuickWin {
     query: string;
     clicks: number;
@@ -6,5 +7,5 @@ interface QuickWin {
     position: number;
     opportunity: number;
 }
-export declare function quickWins(days?: number, minImpressions?: number, maxPosition?: number): Promise<QuickWin[]>;
+export declare function quickWins(days?: number, minImpressions?: number, maxPosition?: number, searchType?: SearchType): Promise<QuickWin[]>;
 export {};

--- a/dist/tools/quick-wins.d.ts
+++ b/dist/tools/quick-wins.d.ts
@@ -7,5 +7,5 @@ interface QuickWin {
     position: number;
     opportunity: number;
 }
-export declare function quickWins(days?: number, minImpressions?: number, maxPosition?: number, searchType?: SearchType): Promise<QuickWin[]>;
+export declare function quickWins(days?: number, minImpressions?: number, maxPosition?: number, searchType?: SearchType, device?: string, country?: string): Promise<QuickWin[]>;
 export {};

--- a/dist/tools/quick-wins.js
+++ b/dist/tools/quick-wins.js
@@ -11,12 +11,14 @@ function expectedCtrAtPosition(pos) {
         return EXPECTED_CTR[Math.floor(pos) - 1];
     return Math.max(0.005, 0.025 - (pos - 10) * 0.002);
 }
-async function quickWins(days = 28, minImpressions = 100, maxPosition = 15) {
+async function quickWins(days = 28, minImpressions = 100, maxPosition = 15, searchType = "web") {
+    (0, analytics_js_1.assertValidDimensions)(searchType, ["query"]);
     const { startDate, endDate } = (0, analytics_js_1.getDateRange)(days);
     const rows = await (0, analytics_js_1.fetchAllRows)({
         startDate,
         endDate,
         dimensions: ["query"],
+        searchType,
     });
     const wins = [];
     for (const row of rows) {

--- a/dist/tools/quick-wins.js
+++ b/dist/tools/quick-wins.js
@@ -11,10 +11,13 @@ function expectedCtrAtPosition(pos) {
         return EXPECTED_CTR[Math.floor(pos) - 1];
     return Math.max(0.005, 0.025 - (pos - 10) * 0.002);
 }
-async function quickWins(days = 28, minImpressions = 100, maxPosition = 15, searchType = "web") {
+async function quickWins(days = 28, minImpressions = 100, maxPosition = 15, searchType = "web", device, country) {
     (0, analytics_js_1.assertValidDimensions)(searchType, ["query"]);
     const { startDate, endDate } = (0, analytics_js_1.getDateRange)(days);
+    const extra = (0, analytics_js_1.deviceCountryFilters)(device, country, searchType);
+    const dimensionFilterGroups = extra.length ? [{ filters: extra }] : undefined;
     const rows = await (0, analytics_js_1.fetchAllRows)({
+        dimensionFilterGroups,
         startDate,
         endDate,
         dimensions: ["query"],

--- a/dist/tools/search-appearance.d.ts
+++ b/dist/tools/search-appearance.d.ts
@@ -1,0 +1,42 @@
+import { SearchType } from "../analytics.js";
+interface AppearanceRow {
+    appearance: string;
+    clicks: number;
+    impressions: number;
+    ctr: number;
+    position: number;
+}
+interface DrillRow {
+    key: string;
+    clicks: number;
+    impressions: number;
+    ctr: number;
+    position: number;
+}
+interface SearchAppearanceResult {
+    surface: SearchType;
+    mode: "breakdown" | "drilldown";
+    period: {
+        startDate: string;
+        endDate: string;
+    };
+    appearanceBreakdown: AppearanceRow[];
+    drilldown?: {
+        appearance: string;
+        dimension: "page" | "query";
+        rows: DrillRow[];
+    };
+    note: string;
+}
+/**
+ * Search-appearance breakdown (rich-result / feature types). Common values include
+ * MERCHANT_LISTINGS (Händlereinträge), PRODUCT_SNIPPETS, REVIEW_SNIPPET,
+ * RECIPE_FEATURE, VIDEO, AMP_* and others — the exact set is whatever the property
+ * is eligible for. The API requires searchAppearance to be queried alone, so to see
+ * which pages/queries drive a given appearance you must filter on it (drilldown).
+ *
+ * @param appearance Optional. If provided, drills into that appearance type and
+ *                   returns the top pages (or queries) driving it.
+ */
+export declare function searchAppearance(days?: number, appearance?: string, drillDimension?: "page" | "query", searchType?: SearchType, rowLimit?: number, siteUrl?: string): Promise<SearchAppearanceResult>;
+export {};

--- a/dist/tools/search-appearance.js
+++ b/dist/tools/search-appearance.js
@@ -1,0 +1,74 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.searchAppearance = searchAppearance;
+const analytics_js_1 = require("../analytics.js");
+/**
+ * Search-appearance breakdown (rich-result / feature types). Common values include
+ * MERCHANT_LISTINGS (Händlereinträge), PRODUCT_SNIPPETS, REVIEW_SNIPPET,
+ * RECIPE_FEATURE, VIDEO, AMP_* and others — the exact set is whatever the property
+ * is eligible for. The API requires searchAppearance to be queried alone, so to see
+ * which pages/queries drive a given appearance you must filter on it (drilldown).
+ *
+ * @param appearance Optional. If provided, drills into that appearance type and
+ *                   returns the top pages (or queries) driving it.
+ */
+async function searchAppearance(days = 28, appearance, drillDimension = "page", searchType = "web", rowLimit = 50, siteUrl) {
+    const period = (0, analytics_js_1.getDateRange)(days);
+    // Step 1: always fetch the full appearance breakdown (searchAppearance alone).
+    const breakdownRows = await (0, analytics_js_1.fetchAllRows)({
+        startDate: period.startDate,
+        endDate: period.endDate,
+        dimensions: ["searchAppearance"],
+        searchType,
+    }, siteUrl);
+    const appearanceBreakdown = breakdownRows
+        .sort((a, b) => b.impressions - a.impressions)
+        .map((r) => ({
+        appearance: r.keys[0],
+        clicks: r.clicks,
+        impressions: r.impressions,
+        ctr: Math.round(r.ctr * 10000) / 100,
+        position: Math.round(r.position * 10) / 10,
+    }));
+    let drilldown;
+    // Step 2: optional drilldown — filter on the appearance, group by page/query.
+    if (appearance) {
+        const drillRows = await (0, analytics_js_1.fetchAllRows)({
+            startDate: period.startDate,
+            endDate: period.endDate,
+            dimensions: [drillDimension],
+            searchType,
+            dimensionFilterGroups: [
+                {
+                    filters: [
+                        { dimension: "searchAppearance", operator: "equals", expression: appearance },
+                    ],
+                },
+            ],
+        }, siteUrl);
+        drilldown = {
+            appearance,
+            dimension: drillDimension,
+            rows: drillRows
+                .sort((a, b) => b.clicks - a.clicks)
+                .slice(0, Math.min(rowLimit, 200))
+                .map((r) => ({
+                key: r.keys[0],
+                clicks: r.clicks,
+                impressions: r.impressions,
+                ctr: Math.round(r.ctr * 10000) / 100,
+                position: Math.round(r.position * 10) / 10,
+            })),
+        };
+    }
+    return {
+        surface: searchType,
+        mode: appearance ? "drilldown" : "breakdown",
+        period,
+        appearanceBreakdown,
+        drilldown,
+        note: appearance
+            ? `Top ${drilldown?.dimension ?? "page"}s for appearance "${appearance}". Filtered via dimensionFilterGroups.`
+            : "Appearance-type breakdown. Pass an `appearance` value (e.g. MERCHANT_LISTINGS) to drill into the pages or queries driving it.",
+    };
+}

--- a/dist/tools/topic-cluster-performance.d.ts
+++ b/dist/tools/topic-cluster-performance.d.ts
@@ -1,3 +1,4 @@
+import { SearchType } from "../analytics.js";
 interface ClusterPerformance {
     pathPattern: string;
     totalClicks: number;
@@ -18,5 +19,5 @@ interface ClusterPerformance {
         position: number;
     }>;
 }
-export declare function topicClusterPerformance(pathPattern: string, days?: number): Promise<ClusterPerformance>;
+export declare function topicClusterPerformance(pathPattern: string, days?: number, searchType?: SearchType): Promise<ClusterPerformance>;
 export {};

--- a/dist/tools/topic-cluster-performance.js
+++ b/dist/tools/topic-cluster-performance.js
@@ -2,13 +2,15 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.topicClusterPerformance = topicClusterPerformance;
 const analytics_js_1 = require("../analytics.js");
-async function topicClusterPerformance(pathPattern, days = 28) {
+async function topicClusterPerformance(pathPattern, days = 28, searchType = "web") {
     const { startDate, endDate } = (0, analytics_js_1.getDateRange)(days);
+    const supportsQuery = analytics_js_1.ALLOWED_DIMENSIONS[searchType].includes("query");
     // Fetch page-level data filtered by URL pattern
     const pageRows = await (0, analytics_js_1.fetchAllRows)({
         startDate,
         endDate,
         dimensions: ["page"],
+        searchType,
         dimensionFilterGroups: [
             {
                 filters: [
@@ -21,23 +23,27 @@ async function topicClusterPerformance(pathPattern, days = 28) {
             },
         ],
     });
-    // Fetch query-level data filtered by URL pattern
-    const queryRows = await (0, analytics_js_1.fetchAllRows)({
-        startDate,
-        endDate,
-        dimensions: ["query"],
-        dimensionFilterGroups: [
-            {
-                filters: [
-                    {
-                        dimension: "page",
-                        operator: "contains",
-                        expression: pathPattern,
-                    },
-                ],
-            },
-        ],
-    });
+    // Fetch query-level data filtered by URL pattern.
+    // Surfaces like Discover have no query dimension, so skip it there.
+    const queryRows = supportsQuery
+        ? await (0, analytics_js_1.fetchAllRows)({
+            startDate,
+            endDate,
+            dimensions: ["query"],
+            searchType,
+            dimensionFilterGroups: [
+                {
+                    filters: [
+                        {
+                            dimension: "page",
+                            operator: "contains",
+                            expression: pathPattern,
+                        },
+                    ],
+                },
+            ],
+        })
+        : [];
     let totalClicks = 0;
     let totalImpressions = 0;
     let positionSum = 0;

--- a/dist/tools/traffic-drops.d.ts
+++ b/dist/tools/traffic-drops.d.ts
@@ -1,3 +1,4 @@
+import { SearchType } from "../analytics.js";
 interface TrafficDrop {
     page: string;
     currentClicks: number;
@@ -8,5 +9,5 @@ interface TrafficDrop {
     positionChange: number;
     diagnosis: string;
 }
-export declare function trafficDrops(days?: number): Promise<TrafficDrop[]>;
+export declare function trafficDrops(days?: number, searchType?: SearchType): Promise<TrafficDrop[]>;
 export {};

--- a/dist/tools/traffic-drops.js
+++ b/dist/tools/traffic-drops.js
@@ -2,12 +2,13 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.trafficDrops = trafficDrops;
 const analytics_js_1 = require("../analytics.js");
-async function trafficDrops(days = 28) {
+async function trafficDrops(days = 28, searchType = "web") {
+    (0, analytics_js_1.assertValidDimensions)(searchType, ["page"]);
     const current = (0, analytics_js_1.getDateRange)(days);
     const prior = (0, analytics_js_1.getPriorDateRange)(days);
     const [currentRows, priorRows] = await Promise.all([
-        (0, analytics_js_1.fetchAllRows)({ startDate: current.startDate, endDate: current.endDate, dimensions: ["page"] }),
-        (0, analytics_js_1.fetchAllRows)({ startDate: prior.startDate, endDate: prior.endDate, dimensions: ["page"] }),
+        (0, analytics_js_1.fetchAllRows)({ startDate: current.startDate, endDate: current.endDate, dimensions: ["page"], searchType }),
+        (0, analytics_js_1.fetchAllRows)({ startDate: prior.startDate, endDate: prior.endDate, dimensions: ["page"], searchType }),
     ]);
     const priorMap = new Map();
     for (const row of priorRows) {

--- a/dist/tools/verify-claim.d.ts
+++ b/dist/tools/verify-claim.d.ts
@@ -1,3 +1,4 @@
+import { SearchType } from "../analytics.js";
 interface VerificationResult {
     claim: string;
     metric: string;
@@ -16,5 +17,5 @@ interface VerificationResult {
  * Verify a specific numeric claim against live GSC data.
  * Use this to self-check before presenting findings to the user.
  */
-export declare function verifyClaim(claim: string, metric: "clicks" | "impressions" | "ctr" | "position", expectedValue: number, url?: string, query?: string, days?: number): Promise<VerificationResult>;
+export declare function verifyClaim(claim: string, metric: "clicks" | "impressions" | "ctr" | "position", expectedValue: number, url?: string, query?: string, days?: number, searchType?: SearchType): Promise<VerificationResult>;
 export {};

--- a/dist/tools/verify-claim.js
+++ b/dist/tools/verify-claim.js
@@ -6,7 +6,7 @@ const analytics_js_1 = require("../analytics.js");
  * Verify a specific numeric claim against live GSC data.
  * Use this to self-check before presenting findings to the user.
  */
-async function verifyClaim(claim, metric, expectedValue, url, query, days = 28) {
+async function verifyClaim(claim, metric, expectedValue, url, query, days = 28, searchType = "web") {
     const { startDate, endDate } = (0, analytics_js_1.getDateRange)(days);
     const dimensions = [];
     const filters = [];
@@ -31,10 +31,13 @@ async function verifyClaim(claim, metric, expectedValue, url, query, days = 28) 
             filters: [{ dimension: "query", operator: "equals", expression: query }],
         });
     }
+    const effectiveDimensions = dimensions.length > 0 ? dimensions : ["date"];
+    (0, analytics_js_1.assertValidDimensions)(searchType, effectiveDimensions);
     const rows = await (0, analytics_js_1.fetchAllRows)({
         startDate,
         endDate,
-        dimensions: dimensions.length > 0 ? dimensions : ["date"],
+        dimensions: effectiveDimensions,
+        searchType,
         dimensionFilterGroups: filters.length > 0 ? filters : undefined,
     });
     let actualValue = null;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "suganthan-gsc-mcp",
-  "version": "2.2.2",
+  "version": "2.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "suganthan-gsc-mcp",
-      "version": "2.2.2",
+      "version": "2.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "suganthan-gsc-mcp",
-  "version": "2.2.2",
-  "description": "Google Search Console MCP server for Claude. 20 SEO analysis tools including quick wins, traffic drops, content decay, cannibalisation, CTR opportunities, and multi-site dashboards. OAuth and service account support.",
+  "version": "2.3.0",
+  "description": "Google Search Console MCP server for Claude. 23 SEO analysis tools including quick wins, traffic drops, content decay, cannibalisation, CTR opportunities, multi-site dashboards, plus isolated Discover, Image and search-appearance (merchant listings) analysis. Most tools accept a surface parameter to query Discover/Image/Video/News. OAuth and service account support.",
   "main": "dist/index.js",
   "bin": {
     "suganthan-gsc-mcp": "dist/index.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "suganthan-gsc-mcp",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "Google Search Console MCP server for Claude. 23 SEO analysis tools including quick wins, traffic drops, content decay, cannibalisation, CTR opportunities, multi-site dashboards, plus isolated Discover, Image and search-appearance (merchant listings) analysis. Most tools accept a surface parameter to query Discover/Image/Video/News. OAuth and service account support.",
   "main": "dist/index.js",
   "bin": {

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -1,5 +1,27 @@
 import { getSearchConsoleClient, getConfig } from "./auth.js";
 
+/**
+ * GSC search types. The API defaults to "web" when type is omitted, which is
+ * why every legacy tool only ever sees web data. Set this explicitly to query
+ * Discover, Image, Video or News surfaces in isolation.
+ */
+export type SearchType = "web" | "image" | "video" | "news" | "discover" | "googleNews";
+
+/**
+ * Dimensions the API actually allows per surface. Used for a friendly guard so
+ * an invalid combination fails with a clear message instead of an opaque 400.
+ * (searchAppearance is special: it must be the ONLY grouping dimension.)
+ */
+export const ALLOWED_DIMENSIONS: Record<SearchType, string[]> = {
+  web: ["query", "page", "country", "device", "date", "searchAppearance"],
+  image: ["query", "page", "country", "device", "date", "searchAppearance"],
+  video: ["query", "page", "country", "device", "date", "searchAppearance"],
+  news: ["query", "page", "country", "device", "date"],
+  // Discover is not query-based: no "query", no "device".
+  discover: ["page", "country", "date", "searchAppearance"],
+  googleNews: ["page", "country", "date"],
+};
+
 export interface SearchAnalyticsRow {
   keys: string[];
   clicks: number;
@@ -12,6 +34,8 @@ export interface QueryParams {
   startDate: string;
   endDate: string;
   dimensions: string[];
+  /** Surface to query. Omit for "web" (the API default). */
+  searchType?: SearchType;
   dimensionFilterGroups?: Array<{
     filters: Array<{
       dimension: string;
@@ -20,6 +44,27 @@ export interface QueryParams {
     }>;
   }>;
   rowLimit?: number;
+}
+
+/**
+ * Validates that the requested dimensions are legal for the chosen surface.
+ * Throws a descriptive error instead of letting the API return a generic 400.
+ */
+export function assertValidDimensions(searchType: SearchType, dimensions: string[]): void {
+  const allowed = ALLOWED_DIMENSIONS[searchType];
+  const invalid = dimensions.filter((d) => !allowed.includes(d));
+  if (invalid.length > 0) {
+    throw new Error(
+      `Dimension(s) [${invalid.join(", ")}] are not supported for searchType "${searchType}". ` +
+        `Allowed: [${allowed.join(", ")}].`
+    );
+  }
+  if (dimensions.includes("searchAppearance") && dimensions.length > 1) {
+    throw new Error(
+      `"searchAppearance" must be the only grouping dimension. ` +
+        `To break a single appearance down by page/query, filter on searchAppearance instead.`
+    );
+  }
 }
 
 function formatDate(date: Date): string {
@@ -72,6 +117,7 @@ export async function fetchAllRows(params: QueryParams, siteUrlOverride?: string
         startDate: params.startDate,
         endDate: params.endDate,
         dimensions: params.dimensions,
+        type: params.searchType, // undefined => API default "web"
         dimensionFilterGroups: params.dimensionFilterGroups,
         rowLimit: pageSize,
         startRow,

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -44,6 +44,8 @@ export interface QueryParams {
     }>;
   }>;
   rowLimit?: number;
+  /** Hard cap on rows fetched across all pages. Omit for no cap. */
+  maxRows?: number;
 }
 
 /**
@@ -139,8 +141,9 @@ export async function fetchAllRows(params: QueryParams, siteUrlOverride?: string
     }
 
     if (rows.length < pageSize) break;
+    if (params.maxRows && allRows.length >= params.maxRows) break;
     startRow += pageSize;
   }
 
-  return allRows;
+  return params.maxRows ? allRows.slice(0, params.maxRows) : allRows;
 }

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -69,6 +69,53 @@ export function assertValidDimensions(searchType: SearchType, dimensions: string
   }
 }
 
+/** Devices as the API spells them in dimension filters. */
+export const DEVICES = ["MOBILE", "DESKTOP", "TABLET"] as const;
+export type Device = (typeof DEVICES)[number];
+
+/**
+ * Dimension filters for device and country.
+ *
+ * Both are optional, and unset means unfiltered - every tool keeps returning
+ * all devices and all countries unless asked otherwise.
+ *
+ * Discover has no device dimension (see ALLOWED_DIMENSIONS), so filtering by
+ * device there is impossible rather than merely empty. That fails loudly.
+ */
+export function deviceCountryFilters(
+  device?: string,
+  country?: string,
+  searchType: SearchType = "web"
+): Array<{ dimension: string; operator: string; expression: string }> {
+  const filters: Array<{ dimension: string; operator: string; expression: string }> = [];
+
+  if (device) {
+    if (!ALLOWED_DIMENSIONS[searchType].includes("device")) {
+      throw new Error(
+        `searchType "${searchType}" has no device dimension, so it cannot be filtered by device. ` +
+          `Allowed dimensions: [${ALLOWED_DIMENSIONS[searchType].join(", ")}].`
+      );
+    }
+    const upper = device.toUpperCase() as Device;
+    if (!DEVICES.includes(upper)) {
+      throw new Error(`Unknown device "${device}". Allowed: ${DEVICES.join(", ")}.`);
+    }
+    filters.push({ dimension: "device", operator: "equals", expression: upper });
+  }
+
+  if (country) {
+    const lower = country.toLowerCase();
+    if (!/^[a-z]{3}$/.test(lower)) {
+      throw new Error(
+        `Country must be an ISO-3166-1 alpha-3 code such as deu, aut, che or usa - got "${country}".`
+      );
+    }
+    filters.push({ dimension: "country", operator: "equals", expression: lower });
+  }
+
+  return filters;
+}
+
 function formatDate(date: Date): string {
   return date.toISOString().split("T")[0];
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,11 +23,21 @@ import { generateReport } from "./tools/generate-report.js";
 import { multiSiteDashboard } from "./tools/multi-site-dashboard.js";
 import { submitUrl, submitBatch } from "./tools/submit-url.js";
 import { submitSitemap, listSitemaps } from "./tools/submit-sitemap.js";
+import { discoverAnalysis } from "./tools/discover-analysis.js";
+import { imageAnalysis } from "./tools/image-analysis.js";
+import { searchAppearance } from "./tools/search-appearance.js";
 
 const server = new McpServer({
   name: "gsc-mcp",
   version: "2.1.0",
 });
+
+// Shared GSC surface (search type) parameter. "web" is the API default and keeps
+// every tool backwards-compatible. Page-based tools also accept "discover";
+// query-based tools accept image/video/news but not discover (no query dimension).
+const SURFACES = ["web", "image", "video", "news", "discover", "googleNews"] as const;
+const surfaceParam = (note: string) =>
+  z.enum(SURFACES).default("web").describe(note);
 
 // 1. Quick Wins
 server.tool(
@@ -37,10 +47,11 @@ server.tool(
     days: z.number().default(28).describe("Number of days to analyse"),
     min_impressions: z.number().default(100).describe("Minimum impressions threshold"),
     max_position: z.number().default(15).describe("Maximum position to include"),
+    surface: surfaceParam("Surface to query: web (default), image, video, news. Discover is NOT supported here (no query dimension)."),
   },
-  async ({ days, min_impressions, max_position }) => {
-    const results = await quickWins(days, min_impressions, max_position);
-    const wrapped = withMeta(results, "quick_wins", { days, min_impressions, max_position });
+  async ({ days, min_impressions, max_position, surface }) => {
+    const results = await quickWins(days, min_impressions, max_position, surface);
+    const wrapped = withMeta(results, "quick_wins", { days, min_impressions, max_position, surface });
     return {
       content: [{ type: "text", text: JSON.stringify(wrapped, null, 2) }],
     };
@@ -54,10 +65,11 @@ server.tool(
   {
     days: z.number().default(28).describe("Number of days to analyse"),
     min_impressions: z.number().default(500).describe("Minimum impressions threshold"),
+    surface: surfaceParam("Surface to query: web (default), image, video, news, discover. Discover is page-based and supported."),
   },
-  async ({ days, min_impressions }) => {
-    const results = await ctrOpportunities(days, min_impressions);
-    const wrapped = withMeta(results, "ctr_opportunities", { days, min_impressions });
+  async ({ days, min_impressions, surface }) => {
+    const results = await ctrOpportunities(days, min_impressions, surface);
+    const wrapped = withMeta(results, "ctr_opportunities", { days, min_impressions, surface });
     return {
       content: [{ type: "text", text: JSON.stringify(wrapped, null, 2) }],
     };
@@ -70,10 +82,11 @@ server.tool(
   "Find pages that lost the most traffic recently. Compares current period vs prior period and diagnoses whether each drop is a ranking loss, CTR collapse, or demand decline." + GUARDRAIL_SUFFIX + VISUAL_SUFFIX,
   {
     days: z.number().default(28).describe("Number of days per period to compare"),
+    surface: surfaceParam("Surface to query: web (default), image, video, news, discover. Discover is page-based and supported."),
   },
-  async ({ days }) => {
-    const results = await trafficDrops(days);
-    const wrapped = withMeta(results, "traffic_drops", { days });
+  async ({ days, surface }) => {
+    const results = await trafficDrops(days, surface);
+    const wrapped = withMeta(results, "traffic_drops", { days, surface });
     return {
       content: [{ type: "text", text: JSON.stringify(wrapped, null, 2) }],
     };
@@ -88,10 +101,11 @@ server.tool(
     days: z.number().default(90).describe("Number of days to analyse"),
     min_impressions: z.number().default(50).describe("Minimum impressions threshold"),
     min_position: z.number().default(20).describe("Minimum position (queries ranking worse than this)"),
+    surface: surfaceParam("Surface to query: web (default), image, video, news. Discover is NOT supported here (no query dimension)."),
   },
-  async ({ days, min_impressions, min_position }) => {
-    const results = await contentGaps(days, min_impressions, min_position);
-    const wrapped = withMeta(results, "content_gaps", { days, min_impressions, min_position });
+  async ({ days, min_impressions, min_position, surface }) => {
+    const results = await contentGaps(days, min_impressions, min_position, surface);
+    const wrapped = withMeta(results, "content_gaps", { days, min_impressions, min_position, surface });
     return {
       content: [{ type: "text", text: JSON.stringify(wrapped, null, 2) }],
     };
@@ -137,10 +151,11 @@ server.tool(
   {
     days: z.number().default(28).describe("Number of days to analyse"),
     min_impressions: z.number().default(50).describe("Minimum combined impressions for a query"),
+    surface: surfaceParam("Surface to query: web (default), image, video, news. Discover is NOT supported here (no query dimension)."),
   },
-  async ({ days, min_impressions }) => {
-    const results = await cannibalizationCheck(days, min_impressions);
-    const wrapped = withMeta(results, "cannibalization_check", { days, min_impressions });
+  async ({ days, min_impressions, surface }) => {
+    const results = await cannibalizationCheck(days, min_impressions, surface);
+    const wrapped = withMeta(results, "cannibalization_check", { days, min_impressions, surface });
     return {
       content: [{ type: "text", text: JSON.stringify(wrapped, null, 2) }],
     };
@@ -151,10 +166,12 @@ server.tool(
 server.tool(
   "content_decay",
   "Find pages that are slowly dying with consistent traffic decline over three consecutive 30-day periods. One bad month is noise; three consecutive bad months is a problem." + GUARDRAIL_SUFFIX + VISUAL_SUFFIX,
-  {},
-  async () => {
-    const results = await contentDecay();
-    const wrapped = withMeta(results, "content_decay", {});
+  {
+    surface: surfaceParam("Surface to query: web (default), image, video, news, discover. Discover is page-based and supported."),
+  },
+  async ({ surface }) => {
+    const results = await contentDecay(surface);
+    const wrapped = withMeta(results, "content_decay", { surface });
     return {
       content: [{ type: "text", text: JSON.stringify(wrapped, null, 2) }],
     };
@@ -168,10 +185,11 @@ server.tool(
   {
     path_pattern: z.string().describe("URL path pattern to match (e.g. /blog/seo)"),
     days: z.number().default(28).describe("Number of days to analyse"),
+    surface: surfaceParam("Surface to query: web (default), image, video, news, discover. On Discover only page-level data is returned (no queries)."),
   },
-  async ({ path_pattern, days }) => {
-    const results = await topicClusterPerformance(path_pattern, days);
-    const wrapped = withMeta(results, "topic_cluster_performance", { path_pattern, days });
+  async ({ path_pattern, days, surface }) => {
+    const results = await topicClusterPerformance(path_pattern, days, surface);
+    const wrapped = withMeta(results, "topic_cluster_performance", { path_pattern, days, surface });
     return {
       content: [{ type: "text", text: JSON.stringify(wrapped, null, 2) }],
     };
@@ -185,10 +203,11 @@ server.tool(
   {
     days: z.number().default(28).describe("Number of days to analyse"),
     min_impressions: z.number().default(200).describe("Minimum impressions threshold"),
+    surface: surfaceParam("Surface to query: web (default), image, video, news, discover. Discover is page-based and supported."),
   },
-  async ({ days, min_impressions }) => {
-    const results = await ctrVsBenchmark(days, min_impressions);
-    const wrapped = withMeta(results, "ctr_vs_benchmark", { days, min_impressions });
+  async ({ days, min_impressions, surface }) => {
+    const results = await ctrVsBenchmark(days, min_impressions, surface);
+    const wrapped = withMeta(results, "ctr_vs_benchmark", { days, min_impressions, surface });
     return {
       content: [{ type: "text", text: JSON.stringify(wrapped, null, 2) }],
     };
@@ -206,9 +225,10 @@ server.tool(
     url: z.string().optional().describe("Filter to a specific URL"),
     query: z.string().optional().describe("Filter to a specific search query"),
     days: z.number().default(28).describe("Number of days to check"),
+    surface: surfaceParam("Surface to query: web (default), image, video, news, discover. On Discover only page-level data is returned (no queries)."),
   },
-  async ({ claim, metric, expected_value, url, query, days }) => {
-    const results = await verifyClaim(claim, metric, expected_value, url, query, days);
+  async ({ claim, metric, expected_value, url, query, days, surface }) => {
+    const results = await verifyClaim(claim, metric, expected_value, url, query, days, surface);
     return {
       content: [{ type: "text", text: JSON.stringify(results, null, 2) }],
     };
@@ -231,10 +251,11 @@ server.tool(
     order_by: z.string().default("clicks").describe("Sort by: clicks, impressions, ctr, position"),
     order_direction: z.string().default("descending").describe("Sort direction: ascending, descending"),
     site_url: z.string().optional().describe("Override the default site URL"),
+    surface: surfaceParam("Surface to query: web (default), image, video, news, discover, googleNews. Dimensions must be valid for the chosen surface."),
   },
-  async ({ days, dimensions, filters, row_limit, order_by, order_direction, site_url }) => {
-    const results = await advancedSearchAnalytics(days, dimensions, filters, row_limit, order_by, order_direction, site_url);
-    const wrapped = withMeta(results, "advanced_search_analytics", { days, dimensions, filters, row_limit, order_by });
+  async ({ days, dimensions, filters, row_limit, order_by, order_direction, site_url, surface }) => {
+    const results = await advancedSearchAnalytics(days, dimensions, filters, row_limit, order_by, order_direction, site_url, surface);
+    const wrapped = withMeta(results, "advanced_search_analytics", { days, dimensions, filters, row_limit, order_by, surface });
     return {
       content: [{ type: "text", text: JSON.stringify(wrapped, null, 2) }],
     };
@@ -250,10 +271,11 @@ server.tool(
     position_drop_threshold: z.number().default(20).describe("Alert if position drops more than this many spots"),
     ctr_drop_threshold: z.number().default(50).describe("Alert if CTR drops more than this percentage"),
     click_drop_threshold: z.number().default(30).describe("Alert if clicks drop more than this percentage"),
+    surface: surfaceParam("Surface to query: web (default), image, video, news. Discover is NOT supported here (no query dimension)."),
   },
-  async ({ days, position_drop_threshold, ctr_drop_threshold, click_drop_threshold }) => {
-    const results = await checkAlerts(days, position_drop_threshold, ctr_drop_threshold, click_drop_threshold);
-    const wrapped = withMeta(results, "check_alerts", { days, position_drop_threshold, ctr_drop_threshold, click_drop_threshold });
+  async ({ days, position_drop_threshold, ctr_drop_threshold, click_drop_threshold, surface }) => {
+    const results = await checkAlerts(days, position_drop_threshold, ctr_drop_threshold, click_drop_threshold, surface);
+    const wrapped = withMeta(results, "check_alerts", { days, position_drop_threshold, ctr_drop_threshold, click_drop_threshold, surface });
     return {
       content: [{ type: "text", text: JSON.stringify(wrapped, null, 2) }],
     };
@@ -366,6 +388,63 @@ server.tool(
   async () => {
     const results = await listSitemaps();
     const wrapped = withMeta(results, "list_sitemaps", {});
+    return {
+      content: [{ type: "text", text: JSON.stringify(wrapped, null, 2) }],
+    };
+  }
+);
+
+// 21. Discover Analysis (isolated)
+server.tool(
+  "discover_analysis",
+  "Analyse Google Discover performance in isolation (type=discover). Discover is feed-based, not query-based, so this returns top pages, country split and a daily clicks/impressions trend with a prior-period comparison. No query-level data or position exists for Discover." + GUARDRAIL_SUFFIX + VISUAL_SUFFIX,
+  {
+    days: z.number().default(28).describe("Number of days per period to compare"),
+    row_limit: z.number().default(50).describe("Max number of top pages to return"),
+    site_url: z.string().optional().describe("Override the configured property"),
+  },
+  async ({ days, row_limit, site_url }) => {
+    const results = await discoverAnalysis(days, row_limit, site_url);
+    const wrapped = withMeta(results, "discover_analysis", { days, row_limit, site_url });
+    return {
+      content: [{ type: "text", text: JSON.stringify(wrapped, null, 2) }],
+    };
+  }
+);
+
+// 22. Image Analysis (isolated)
+server.tool(
+  "image_analysis",
+  "Analyse Google Image search performance in isolation (type=image). Returns top image queries, top pages and a prior-period comparison. Separate from web search data." + GUARDRAIL_SUFFIX + VISUAL_SUFFIX,
+  {
+    days: z.number().default(28).describe("Number of days per period to compare"),
+    row_limit: z.number().default(50).describe("Max number of top queries/pages to return"),
+    site_url: z.string().optional().describe("Override the configured property"),
+  },
+  async ({ days, row_limit, site_url }) => {
+    const results = await imageAnalysis(days, row_limit, site_url);
+    const wrapped = withMeta(results, "image_analysis", { days, row_limit, site_url });
+    return {
+      content: [{ type: "text", text: JSON.stringify(wrapped, null, 2) }],
+    };
+  }
+);
+
+// 23. Search Appearance / Merchant Listings (isolated)
+server.tool(
+  "search_appearance",
+  "Break down performance by search-appearance / rich-result type (the searchAppearance dimension), e.g. MERCHANT_LISTINGS (Händlereinträge), PRODUCT_SNIPPETS, REVIEW_SNIPPET, RECIPE_FEATURE. Without an appearance argument it lists all appearance types with their metrics. Pass an appearance value to drill into the pages or queries driving that specific type." + GUARDRAIL_SUFFIX + VISUAL_SUFFIX,
+  {
+    days: z.number().default(28).describe("Number of days to analyse"),
+    appearance: z.string().optional().describe("Appearance type to drill into, e.g. MERCHANT_LISTINGS. Omit for the full breakdown."),
+    drill_dimension: z.enum(["page", "query"]).default("page").describe("When drilling into an appearance, group by page or query"),
+    search_type: z.enum(["web", "image", "video", "news", "discover", "googleNews"]).default("web").describe("Surface to query the appearance breakdown for"),
+    row_limit: z.number().default(50).describe("Max number of drilldown rows to return"),
+    site_url: z.string().optional().describe("Override the configured property"),
+  },
+  async ({ days, appearance, drill_dimension, search_type, row_limit, site_url }) => {
+    const results = await searchAppearance(days, appearance, drill_dimension, search_type, row_limit, site_url);
+    const wrapped = withMeta(results, "search_appearance", { days, appearance, drill_dimension, search_type, row_limit, site_url });
     return {
       content: [{ type: "text", text: JSON.stringify(wrapped, null, 2) }],
     };

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,10 +26,11 @@ import { submitSitemap, listSitemaps } from "./tools/submit-sitemap.js";
 import { discoverAnalysis } from "./tools/discover-analysis.js";
 import { imageAnalysis } from "./tools/image-analysis.js";
 import { searchAppearance } from "./tools/search-appearance.js";
+import { queryCount } from "./tools/query-count.js";
 
 const server = new McpServer({
   name: "gsc-mcp",
-  version: "2.1.0",
+  version: "2.4.0",
 });
 
 // Shared GSC surface (search type) parameter. "web" is the API default and keeps
@@ -451,10 +452,30 @@ server.tool(
   }
 );
 
+// 24. Query Counting
+server.tool(
+  "query_count",
+  "Count how many distinct queries the property is visible for, split by position group (1-3, 4-10, 11-20, 21-50, 51+), with a comparison to the previous period. Also reports the anonymized-click gap: clicks the site total contains but no query row explains, because those queries fall below Google's privacy threshold. Treat the query count as a floor, never as the complete keyword set." + GUARDRAIL_SUFFIX + VISUAL_SUFFIX,
+  {
+    days: z.number().default(28).describe("Number of days to analyse"),
+    compare_previous: z.boolean().default(true).describe("Also count the immediately preceding period of the same length"),
+    include_pages: z.boolean().default(false).describe("Also count queries per page. Expensive on large sites: needs the page+query dimension pair, capped at 100k rows."),
+    top_pages: z.number().default(25).describe("How many pages to return when include_pages is true"),
+    surface: surfaceParam("Surface to query: web (default), image, video, news. Discover is NOT supported here (no query dimension)."),
+  },
+  async ({ days, compare_previous, include_pages, top_pages, surface }) => {
+    const results = await queryCount(days, compare_previous, include_pages, top_pages, surface);
+    const wrapped = withMeta(results, "query_count", { days, compare_previous, include_pages, top_pages, surface });
+    return {
+      content: [{ type: "text", text: JSON.stringify(wrapped, null, 2) }],
+    };
+  }
+);
+
 async function main() {
   const transport = new StdioServerTransport();
   await server.connect(transport);
-  console.error("GSC MCP server v2.1.0 running on stdio");
+  console.error("GSC MCP server v2.4.0 running on stdio");
 }
 
 main().catch((error) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,10 +49,12 @@ server.tool(
     min_impressions: z.number().default(100).describe("Minimum impressions threshold"),
     max_position: z.number().default(15).describe("Maximum position to include"),
     surface: surfaceParam("Surface to query: web (default), image, video, news. Discover is NOT supported here (no query dimension)."),
+    device: z.enum(["MOBILE", "DESKTOP", "TABLET"]).optional().describe("Restrict to one device. Omit for all devices, which is the default. Not available on Discover, which carries no device dimension."),
+    country: z.string().optional().describe("Restrict to one country as an ISO-3166-1 alpha-3 code, e.g. deu, aut, che. Omit for all countries, which is the default."),
   },
-  async ({ days, min_impressions, max_position, surface }) => {
-    const results = await quickWins(days, min_impressions, max_position, surface);
-    const wrapped = withMeta(results, "quick_wins", { days, min_impressions, max_position, surface });
+  async ({ days, min_impressions, max_position, surface, device, country }) => {
+    const results = await quickWins(days, min_impressions, max_position, surface, device, country);
+    const wrapped = withMeta(results, "quick_wins", { days, min_impressions, max_position, surface, device, country });
     return {
       content: [{ type: "text", text: JSON.stringify(wrapped, null, 2) }],
     };
@@ -67,10 +69,12 @@ server.tool(
     days: z.number().default(28).describe("Number of days to analyse"),
     min_impressions: z.number().default(500).describe("Minimum impressions threshold"),
     surface: surfaceParam("Surface to query: web (default), image, video, news, discover. Discover is page-based and supported."),
+    device: z.enum(["MOBILE", "DESKTOP", "TABLET"]).optional().describe("Restrict to one device. Omit for all devices, which is the default. Not available on Discover, which carries no device dimension."),
+    country: z.string().optional().describe("Restrict to one country as an ISO-3166-1 alpha-3 code, e.g. deu, aut, che. Omit for all countries, which is the default."),
   },
-  async ({ days, min_impressions, surface }) => {
-    const results = await ctrOpportunities(days, min_impressions, surface);
-    const wrapped = withMeta(results, "ctr_opportunities", { days, min_impressions, surface });
+  async ({ days, min_impressions, surface, device, country }) => {
+    const results = await ctrOpportunities(days, min_impressions, surface, device, country);
+    const wrapped = withMeta(results, "ctr_opportunities", { days, min_impressions, surface, device, country });
     return {
       content: [{ type: "text", text: JSON.stringify(wrapped, null, 2) }],
     };
@@ -169,10 +173,12 @@ server.tool(
   "Find pages that are slowly dying with consistent traffic decline over three consecutive 30-day periods. One bad month is noise; three consecutive bad months is a problem." + GUARDRAIL_SUFFIX + VISUAL_SUFFIX,
   {
     surface: surfaceParam("Surface to query: web (default), image, video, news, discover. Discover is page-based and supported."),
+    device: z.enum(["MOBILE", "DESKTOP", "TABLET"]).optional().describe("Restrict to one device. Omit for all devices, which is the default. Not available on Discover, which carries no device dimension."),
+    country: z.string().optional().describe("Restrict to one country as an ISO-3166-1 alpha-3 code, e.g. deu, aut, che. Omit for all countries, which is the default."),
   },
-  async ({ surface }) => {
-    const results = await contentDecay(surface);
-    const wrapped = withMeta(results, "content_decay", { surface });
+  async ({ surface, device, country }) => {
+    const results = await contentDecay(surface, device, country);
+    const wrapped = withMeta(results, "content_decay", { surface, device, country });
     return {
       content: [{ type: "text", text: JSON.stringify(wrapped, null, 2) }],
     };
@@ -467,10 +473,12 @@ server.tool(
     include_pages: z.boolean().default(false).describe("Also rank pages by query count. Expensive: needs the page+query dimension pair, capped at 100k rows."),
     top_pages: z.number().default(25).describe("How many pages to return when include_pages is true"),
     surface: surfaceParam("Surface to query: web (default), image, video, news. Discover is NOT supported here (no query dimension)."),
+    device: z.enum(["MOBILE", "DESKTOP", "TABLET"]).optional().describe("Restrict to one device. Omit for all devices, which is the default. Not available on Discover, which carries no device dimension."),
+    country: z.string().optional().describe("Restrict to one country as an ISO-3166-1 alpha-3 code, e.g. deu, aut, che. Omit for all countries, which is the default."),
   },
-  async ({ days, url, url_contains, granularity, min_position, max_position, compare_previous, include_pages, top_pages, surface }) => {
-    const results = await queryCount(days, compare_previous, include_pages, top_pages, surface, url, url_contains, granularity, min_position, max_position);
-    const wrapped = withMeta(results, "query_count", { days, url, url_contains, granularity, min_position, max_position, compare_previous, include_pages, top_pages, surface });
+  async ({ days, url, url_contains, granularity, min_position, max_position, compare_previous, include_pages, top_pages, surface, device, country }) => {
+    const results = await queryCount(days, compare_previous, include_pages, top_pages, surface, url, url_contains, granularity, min_position, max_position, device, country);
+    const wrapped = withMeta(results, "query_count", { days, url, url_contains, granularity, min_position, max_position, compare_previous, include_pages, top_pages, surface, device, country });
     return {
       content: [{ type: "text", text: JSON.stringify(wrapped, null, 2) }],
     };

--- a/src/index.ts
+++ b/src/index.ts
@@ -455,17 +455,22 @@ server.tool(
 // 24. Query Counting
 server.tool(
   "query_count",
-  "Count how many distinct queries the property is visible for, split by position group (1-3, 4-10, 11-20, 21-50, 51+), with a comparison to the previous period. Also reports the anonymized-click gap: clicks the site total contains but no query row explains, because those queries fall below Google's privacy threshold. Treat the query count as a floor, never as the complete keyword set." + GUARDRAIL_SUFFIX + VISUAL_SUFFIX,
+  "Count how many distinct queries a property, a section or a single URL is visible for, split by position group (1-3, 4-10, 11-20, 21-50, 51+). Scope it with url (one page) or url_contains (a path), turn it into a time series with granularity (day/week/month), and narrow it with min_position/max_position. Also reports the anonymized-click gap: clicks the totals contain but no query row explains, because those queries fall below Google's privacy threshold. The query count is a floor, never the complete keyword set." + GUARDRAIL_SUFFIX + VISUAL_SUFFIX,
   {
     days: z.number().default(28).describe("Number of days to analyse"),
+    url: z.string().optional().describe("Count only queries for this exact URL"),
+    url_contains: z.string().optional().describe("Count only queries for URLs containing this string, e.g. /ratgeber/"),
+    granularity: z.enum(["none", "day", "week", "month"]).default("none").describe("Return a time series of query counts. One API request per bucket, so day-level is capped at 90 days."),
+    min_position: z.number().optional().describe("Only count queries at this average position or worse (e.g. 4)"),
+    max_position: z.number().optional().describe("Only count queries at this average position or better (e.g. 10)"),
     compare_previous: z.boolean().default(true).describe("Also count the immediately preceding period of the same length"),
-    include_pages: z.boolean().default(false).describe("Also count queries per page. Expensive on large sites: needs the page+query dimension pair, capped at 100k rows."),
+    include_pages: z.boolean().default(false).describe("Also rank pages by query count. Expensive: needs the page+query dimension pair, capped at 100k rows."),
     top_pages: z.number().default(25).describe("How many pages to return when include_pages is true"),
     surface: surfaceParam("Surface to query: web (default), image, video, news. Discover is NOT supported here (no query dimension)."),
   },
-  async ({ days, compare_previous, include_pages, top_pages, surface }) => {
-    const results = await queryCount(days, compare_previous, include_pages, top_pages, surface);
-    const wrapped = withMeta(results, "query_count", { days, compare_previous, include_pages, top_pages, surface });
+  async ({ days, url, url_contains, granularity, min_position, max_position, compare_previous, include_pages, top_pages, surface }) => {
+    const results = await queryCount(days, compare_previous, include_pages, top_pages, surface, url, url_contains, granularity, min_position, max_position);
+    const wrapped = withMeta(results, "query_count", { days, url, url_contains, granularity, min_position, max_position, compare_previous, include_pages, top_pages, surface });
     return {
       content: [{ type: "text", text: JSON.stringify(wrapped, null, 2) }],
     };

--- a/src/tools/advanced-search-analytics.ts
+++ b/src/tools/advanced-search-analytics.ts
@@ -1,4 +1,4 @@
-import { fetchAllRows, getDateRange, SearchAnalyticsRow } from "../analytics.js";
+import { fetchAllRows, getDateRange, SearchAnalyticsRow, SearchType, assertValidDimensions } from "../analytics.js";
 
 interface Filter {
   dimension: string;
@@ -27,8 +27,10 @@ export async function advancedSearchAnalytics(
   rowLimit: number = 100,
   orderBy: string = "clicks",
   orderDirection: string = "descending",
-  siteUrl?: string
+  siteUrl?: string,
+  searchType: SearchType = "web"
 ): Promise<AdvancedSearchResult> {
+  assertValidDimensions(searchType, dimensions);
   const { startDate, endDate } = getDateRange(days);
 
   // Build dimension filter groups from user-provided filters
@@ -47,6 +49,7 @@ export async function advancedSearchAnalytics(
       startDate,
       endDate,
       dimensions,
+      searchType,
       dimensionFilterGroups,
     },
     siteUrl

--- a/src/tools/cannibalization-check.ts
+++ b/src/tools/cannibalization-check.ts
@@ -1,4 +1,4 @@
-import { fetchAllRows, getDateRange } from "../analytics.js";
+import { fetchAllRows, getDateRange, SearchType, assertValidDimensions } from "../analytics.js";
 
 interface CannibalizationIssue {
   query: string;
@@ -13,14 +13,17 @@ interface CannibalizationIssue {
 
 export async function cannibalizationCheck(
   days: number = 28,
-  minImpressions: number = 50
+  minImpressions: number = 50,
+  searchType: SearchType = "web"
 ): Promise<CannibalizationIssue[]> {
+  assertValidDimensions(searchType, ["query", "page"]);
   const { startDate, endDate } = getDateRange(days);
 
   const rows = await fetchAllRows({
     startDate,
     endDate,
     dimensions: ["query", "page"],
+    searchType,
   });
 
   // Group by query

--- a/src/tools/check-alerts.ts
+++ b/src/tools/check-alerts.ts
@@ -1,4 +1,4 @@
-import { fetchAllRows, getDateRange, getPriorDateRange } from "../analytics.js";
+import { fetchAllRows, getDateRange, getPriorDateRange, SearchType, assertValidDimensions } from "../analytics.js";
 
 interface Alert {
   severity: "critical" | "warning" | "info";
@@ -30,15 +30,17 @@ export async function checkAlerts(
   days: number = 7,
   positionDropThreshold: number = 20,
   ctrDropThreshold: number = 50,
-  clickDropThreshold: number = 30
+  clickDropThreshold: number = 30,
+  searchType: SearchType = "web"
 ): Promise<AlertResult> {
+  assertValidDimensions(searchType, ["query", "page"]);
   const current = getDateRange(days);
   const prior = getPriorDateRange(days);
 
   // Fetch query+page level data for both periods
   const [currentRows, priorRows] = await Promise.all([
-    fetchAllRows({ startDate: current.startDate, endDate: current.endDate, dimensions: ["query", "page"] }),
-    fetchAllRows({ startDate: prior.startDate, endDate: prior.endDate, dimensions: ["query", "page"] }),
+    fetchAllRows({ startDate: current.startDate, endDate: current.endDate, dimensions: ["query", "page"], searchType }),
+    fetchAllRows({ startDate: prior.startDate, endDate: prior.endDate, dimensions: ["query", "page"], searchType }),
   ]);
 
   // Build prior period lookup: key = "query|||page"

--- a/src/tools/content-decay.ts
+++ b/src/tools/content-decay.ts
@@ -1,4 +1,4 @@
-import { fetchAllRows } from "../analytics.js";
+import { fetchAllRows, SearchType, assertValidDimensions } from "../analytics.js";
 
 interface DecayingPage {
   page: string;
@@ -16,7 +16,10 @@ function formatDate(date: Date): string {
   return date.toISOString().split("T")[0];
 }
 
-export async function contentDecay(): Promise<DecayingPage[]> {
+export async function contentDecay(
+  searchType: SearchType = "web"
+): Promise<DecayingPage[]> {
+  assertValidDimensions(searchType, ["page"]);
   const now = new Date();
   now.setDate(now.getDate() - 1); // yesterday
 
@@ -38,9 +41,9 @@ export async function contentDecay(): Promise<DecayingPage[]> {
   p3Start.setDate(p3Start.getDate() - 29);
 
   const [rows1, rows2, rows3] = await Promise.all([
-    fetchAllRows({ startDate: formatDate(p1Start), endDate: formatDate(p1End), dimensions: ["page"] }),
-    fetchAllRows({ startDate: formatDate(p2Start), endDate: formatDate(p2End), dimensions: ["page"] }),
-    fetchAllRows({ startDate: formatDate(p3Start), endDate: formatDate(p3End), dimensions: ["page"] }),
+    fetchAllRows({ startDate: formatDate(p1Start), endDate: formatDate(p1End), dimensions: ["page"], searchType }),
+    fetchAllRows({ startDate: formatDate(p2Start), endDate: formatDate(p2End), dimensions: ["page"], searchType }),
+    fetchAllRows({ startDate: formatDate(p3Start), endDate: formatDate(p3End), dimensions: ["page"], searchType }),
   ]);
 
   const toMap = (rows: typeof rows1) => {

--- a/src/tools/content-decay.ts
+++ b/src/tools/content-decay.ts
@@ -1,4 +1,9 @@
-import { fetchAllRows, SearchType, assertValidDimensions } from "../analytics.js";
+import {
+  fetchAllRows,
+  SearchType,
+  assertValidDimensions,
+  deviceCountryFilters,
+} from "../analytics.js";
 
 interface DecayingPage {
   page: string;
@@ -17,9 +22,13 @@ function formatDate(date: Date): string {
 }
 
 export async function contentDecay(
-  searchType: SearchType = "web"
+  searchType: SearchType = "web",
+  device?: string,
+  country?: string
 ): Promise<DecayingPage[]> {
   assertValidDimensions(searchType, ["page"]);
+  const extra = deviceCountryFilters(device, country, searchType);
+  const dimensionFilterGroups = extra.length ? [{ filters: extra }] : undefined;
   const now = new Date();
   now.setDate(now.getDate() - 1); // yesterday
 
@@ -41,9 +50,9 @@ export async function contentDecay(
   p3Start.setDate(p3Start.getDate() - 29);
 
   const [rows1, rows2, rows3] = await Promise.all([
-    fetchAllRows({ startDate: formatDate(p1Start), endDate: formatDate(p1End), dimensions: ["page"], searchType }),
-    fetchAllRows({ startDate: formatDate(p2Start), endDate: formatDate(p2End), dimensions: ["page"], searchType }),
-    fetchAllRows({ startDate: formatDate(p3Start), endDate: formatDate(p3End), dimensions: ["page"], searchType }),
+    fetchAllRows({ startDate: formatDate(p1Start), endDate: formatDate(p1End), dimensions: ["page"], searchType, dimensionFilterGroups }),
+    fetchAllRows({ startDate: formatDate(p2Start), endDate: formatDate(p2End), dimensions: ["page"], searchType, dimensionFilterGroups }),
+    fetchAllRows({ startDate: formatDate(p3Start), endDate: formatDate(p3End), dimensions: ["page"], searchType, dimensionFilterGroups }),
   ]);
 
   const toMap = (rows: typeof rows1) => {

--- a/src/tools/content-gaps.ts
+++ b/src/tools/content-gaps.ts
@@ -1,4 +1,4 @@
-import { fetchAllRows, getDateRange } from "../analytics.js";
+import { fetchAllRows, getDateRange, SearchType, assertValidDimensions } from "../analytics.js";
 
 interface ContentGap {
   query: string;
@@ -10,14 +10,17 @@ interface ContentGap {
 export async function contentGaps(
   days: number = 90,
   minImpressions: number = 50,
-  minPosition: number = 20
+  minPosition: number = 20,
+  searchType: SearchType = "web"
 ): Promise<ContentGap[]> {
+  assertValidDimensions(searchType, ["query"]);
   const { startDate, endDate } = getDateRange(days);
 
   const rows = await fetchAllRows({
     startDate,
     endDate,
     dimensions: ["query"],
+    searchType,
   });
 
   const gaps: ContentGap[] = [];

--- a/src/tools/ctr-opportunities.ts
+++ b/src/tools/ctr-opportunities.ts
@@ -1,4 +1,4 @@
-import { fetchAllRows, getDateRange } from "../analytics.js";
+import { fetchAllRows, getDateRange, SearchType, assertValidDimensions } from "../analytics.js";
 
 const EXPECTED_CTR = [0.285, 0.157, 0.110, 0.080, 0.072, 0.051, 0.040, 0.032, 0.028, 0.025];
 
@@ -21,14 +21,17 @@ interface CtrOpportunity {
 
 export async function ctrOpportunities(
   days: number = 28,
-  minImpressions: number = 500
+  minImpressions: number = 500,
+  searchType: SearchType = "web"
 ): Promise<CtrOpportunity[]> {
+  assertValidDimensions(searchType, ["page"]);
   const { startDate, endDate } = getDateRange(days);
 
   const rows = await fetchAllRows({
     startDate,
     endDate,
     dimensions: ["page"],
+    searchType,
   });
 
   const opportunities: CtrOpportunity[] = [];

--- a/src/tools/ctr-opportunities.ts
+++ b/src/tools/ctr-opportunities.ts
@@ -1,4 +1,10 @@
-import { fetchAllRows, getDateRange, SearchType, assertValidDimensions } from "../analytics.js";
+import {
+  fetchAllRows,
+  getDateRange,
+  SearchType,
+  assertValidDimensions,
+  deviceCountryFilters,
+} from "../analytics.js";
 
 const EXPECTED_CTR = [0.285, 0.157, 0.110, 0.080, 0.072, 0.051, 0.040, 0.032, 0.028, 0.025];
 
@@ -22,12 +28,17 @@ interface CtrOpportunity {
 export async function ctrOpportunities(
   days: number = 28,
   minImpressions: number = 500,
-  searchType: SearchType = "web"
+  searchType: SearchType = "web",
+  device?: string,
+  country?: string
 ): Promise<CtrOpportunity[]> {
   assertValidDimensions(searchType, ["page"]);
   const { startDate, endDate } = getDateRange(days);
+  const extra = deviceCountryFilters(device, country, searchType);
+  const dimensionFilterGroups = extra.length ? [{ filters: extra }] : undefined;
 
   const rows = await fetchAllRows({
+    dimensionFilterGroups,
     startDate,
     endDate,
     dimensions: ["page"],

--- a/src/tools/ctr-vs-benchmark.ts
+++ b/src/tools/ctr-vs-benchmark.ts
@@ -1,4 +1,4 @@
-import { fetchAllRows, getDateRange } from "../analytics.js";
+import { fetchAllRows, getDateRange, SearchType, assertValidDimensions } from "../analytics.js";
 
 const BENCHMARK_CTR = [0.285, 0.157, 0.110, 0.080, 0.072, 0.051, 0.040, 0.032, 0.028, 0.025];
 
@@ -21,14 +21,17 @@ interface CtrBenchmarkResult {
 
 export async function ctrVsBenchmark(
   days: number = 28,
-  minImpressions: number = 200
+  minImpressions: number = 200,
+  searchType: SearchType = "web"
 ): Promise<CtrBenchmarkResult[]> {
+  assertValidDimensions(searchType, ["page"]);
   const { startDate, endDate } = getDateRange(days);
 
   const rows = await fetchAllRows({
     startDate,
     endDate,
     dimensions: ["page"],
+    searchType,
   });
 
   const results: CtrBenchmarkResult[] = [];

--- a/src/tools/discover-analysis.ts
+++ b/src/tools/discover-analysis.ts
@@ -1,0 +1,126 @@
+import {
+  fetchAllRows,
+  getDateRange,
+  getPriorDateRange,
+  assertValidDimensions,
+} from "../analytics.js";
+
+interface PeriodTotals {
+  clicks: number;
+  impressions: number;
+  ctr: number;
+}
+
+interface DiscoverPage {
+  page: string;
+  clicks: number;
+  impressions: number;
+  ctr: number;
+}
+
+interface DiscoverAnalysisResult {
+  surface: "discover";
+  period: { startDate: string; endDate: string };
+  totals: PeriodTotals;
+  change: { clicksPercent: number; impressionsPercent: number };
+  topPages: DiscoverPage[];
+  byCountry: Array<{ country: string; clicks: number; impressions: number; ctr: number }>;
+  dailyTrend: Array<{ date: string; clicks: number; impressions: number }>;
+  note: string;
+}
+
+function totals(rows: { clicks: number; impressions: number }[]): PeriodTotals {
+  let clicks = 0;
+  let impressions = 0;
+  for (const r of rows) {
+    clicks += r.clicks;
+    impressions += r.impressions;
+  }
+  return {
+    clicks,
+    impressions,
+    ctr: impressions > 0 ? Math.round((clicks / impressions) * 10000) / 100 : 0,
+  };
+}
+
+function pct(curr: number, prior: number): number {
+  return prior > 0 ? Math.round(((curr - prior) / prior) * 10000) / 100 : 0;
+}
+
+/**
+ * Isolated Google Discover performance. Discover is NOT query-based, so the API
+ * only supports page / country / date dimensions here. Position/CTR-vs-position
+ * benchmarks from web tools do not apply.
+ */
+export async function discoverAnalysis(
+  days: number = 28,
+  rowLimit: number = 50,
+  siteUrl?: string
+): Promise<DiscoverAnalysisResult> {
+  const current = getDateRange(days);
+  const prior = getPriorDateRange(days);
+
+  assertValidDimensions("discover", ["page"]);
+
+  const [pageRows, priorPageRows, countryRows, dateRows] = await Promise.all([
+    fetchAllRows(
+      { startDate: current.startDate, endDate: current.endDate, dimensions: ["page"], searchType: "discover" },
+      siteUrl
+    ),
+    fetchAllRows(
+      { startDate: prior.startDate, endDate: prior.endDate, dimensions: ["page"], searchType: "discover" },
+      siteUrl
+    ),
+    fetchAllRows(
+      { startDate: current.startDate, endDate: current.endDate, dimensions: ["country"], searchType: "discover" },
+      siteUrl
+    ),
+    fetchAllRows(
+      { startDate: current.startDate, endDate: current.endDate, dimensions: ["date"], searchType: "discover" },
+      siteUrl
+    ),
+  ]);
+
+  const curTotals = totals(pageRows);
+  const priorTotals = totals(priorPageRows);
+
+  const topPages = pageRows
+    .sort((a, b) => b.clicks - a.clicks)
+    .slice(0, Math.min(rowLimit, 200))
+    .map((r) => ({
+      page: r.keys[0],
+      clicks: r.clicks,
+      impressions: r.impressions,
+      ctr: Math.round(r.ctr * 10000) / 100,
+    }));
+
+  const byCountry = countryRows
+    .sort((a, b) => b.clicks - a.clicks)
+    .slice(0, 15)
+    .map((r) => ({
+      country: r.keys[0],
+      clicks: r.clicks,
+      impressions: r.impressions,
+      ctr: Math.round(r.ctr * 10000) / 100,
+    }));
+
+  const dailyTrend = dateRows
+    .sort((a, b) => a.keys[0].localeCompare(b.keys[0]))
+    .map((r) => ({ date: r.keys[0], clicks: r.clicks, impressions: r.impressions }));
+
+  return {
+    surface: "discover",
+    period: current,
+    totals: curTotals,
+    change: {
+      clicksPercent: pct(curTotals.clicks, priorTotals.clicks),
+      impressionsPercent: pct(curTotals.impressions, priorTotals.impressions),
+    },
+    topPages,
+    byCountry,
+    dailyTrend,
+    note:
+      "Google Discover is feed-based, not query-based. There are no query-level rows " +
+      "and average position is not meaningful here. Optimise on title, hero image and freshness.",
+  };
+}

--- a/src/tools/image-analysis.ts
+++ b/src/tools/image-analysis.ts
@@ -1,0 +1,115 @@
+import { fetchAllRows, getDateRange, getPriorDateRange } from "../analytics.js";
+
+interface PeriodTotals {
+  clicks: number;
+  impressions: number;
+  ctr: number;
+  position: number;
+}
+
+interface ImageAnalysisResult {
+  surface: "image";
+  period: { startDate: string; endDate: string };
+  totals: PeriodTotals;
+  change: { clicksPercent: number; impressionsPercent: number; position: number };
+  topQueries: Array<{ query: string; clicks: number; impressions: number; ctr: number; position: number }>;
+  topPages: Array<{ page: string; clicks: number; impressions: number; ctr: number; position: number }>;
+  note: string;
+}
+
+function summarise(rows: { clicks: number; impressions: number; position: number }[]): PeriodTotals {
+  let clicks = 0;
+  let impressions = 0;
+  let posSum = 0;
+  let posCount = 0;
+  for (const r of rows) {
+    clicks += r.clicks;
+    impressions += r.impressions;
+    posSum += r.position;
+    posCount++;
+  }
+  return {
+    clicks,
+    impressions,
+    ctr: impressions > 0 ? Math.round((clicks / impressions) * 10000) / 100 : 0,
+    position: posCount > 0 ? Math.round((posSum / posCount) * 10) / 10 : 0,
+  };
+}
+
+function pct(curr: number, prior: number): number {
+  return prior > 0 ? Math.round(((curr - prior) / prior) * 10000) / 100 : 0;
+}
+
+/**
+ * Isolated Google Image search performance. Image search supports the same
+ * dimensions as web (query, page, country, device, date).
+ */
+export async function imageAnalysis(
+  days: number = 28,
+  rowLimit: number = 50,
+  siteUrl?: string
+): Promise<ImageAnalysisResult> {
+  const current = getDateRange(days);
+  const prior = getPriorDateRange(days);
+
+  const [queryRows, pageRows, priorRows] = await Promise.all([
+    fetchAllRows(
+      { startDate: current.startDate, endDate: current.endDate, dimensions: ["query"], searchType: "image" },
+      siteUrl
+    ),
+    fetchAllRows(
+      { startDate: current.startDate, endDate: current.endDate, dimensions: ["page"], searchType: "image" },
+      siteUrl
+    ),
+    fetchAllRows(
+      { startDate: prior.startDate, endDate: prior.endDate, dimensions: ["date"], searchType: "image" },
+      siteUrl
+    ),
+  ]);
+
+  const dateRowsCurrent = await fetchAllRows(
+    { startDate: current.startDate, endDate: current.endDate, dimensions: ["date"], searchType: "image" },
+    siteUrl
+  );
+
+  const curTotals = summarise(dateRowsCurrent);
+  const priorTotals = summarise(priorRows);
+
+  const topQueries = queryRows
+    .sort((a, b) => b.clicks - a.clicks)
+    .slice(0, Math.min(rowLimit, 200))
+    .map((r) => ({
+      query: r.keys[0],
+      clicks: r.clicks,
+      impressions: r.impressions,
+      ctr: Math.round(r.ctr * 10000) / 100,
+      position: Math.round(r.position * 10) / 10,
+    }));
+
+  const topPages = pageRows
+    .sort((a, b) => b.clicks - a.clicks)
+    .slice(0, Math.min(rowLimit, 200))
+    .map((r) => ({
+      page: r.keys[0],
+      clicks: r.clicks,
+      impressions: r.impressions,
+      ctr: Math.round(r.ctr * 10000) / 100,
+      position: Math.round(r.position * 10) / 10,
+    }));
+
+  return {
+    surface: "image",
+    period: current,
+    totals: curTotals,
+    change: {
+      clicksPercent: pct(curTotals.clicks, priorTotals.clicks),
+      impressionsPercent: pct(curTotals.impressions, priorTotals.impressions),
+      position: Math.round((curTotals.position - priorTotals.position) * 10) / 10,
+    },
+    topQueries,
+    topPages,
+    note:
+      "Image search data only. Optimise on filename, alt text, surrounding context, " +
+      "image dimensions and structured data (ImageObject).",
+  };
+}

--- a/src/tools/query-count.ts
+++ b/src/tools/query-count.ts
@@ -1,0 +1,179 @@
+import {
+  fetchAllRows,
+  getDateRange,
+  getPriorDateRange,
+  SearchType,
+  assertValidDimensions,
+} from "../analytics.js";
+
+/**
+ * Query counting: how many distinct queries a site (and each page) is visible
+ * for, split by position group.
+ *
+ * The number GSC hands back is a FLOOR, not the truth: queries below Google's
+ * privacy threshold never appear as rows, so their clicks show up in the site
+ * total but in no query row. We therefore also report that gap explicitly
+ * instead of pretending the query table is complete.
+ */
+
+interface PositionGroupCount {
+  group: string;
+  queries: number;
+  clicks: number;
+  impressions: number;
+  queryShare: number;
+}
+
+interface PageQueryCount {
+  page: string;
+  queries: number;
+  clicks: number;
+  impressions: number;
+}
+
+interface QueryCountResult {
+  period: { startDate: string; endDate: string; days: number };
+  totals: {
+    visibleQueries: number;
+    clicksFromVisibleQueries: number;
+    totalClicks: number;
+    anonymizedClicks: number;
+    anonymizedClicksShare: number;
+  };
+  byPositionGroup: PositionGroupCount[];
+  previousPeriod: {
+    startDate: string;
+    endDate: string;
+    visibleQueries: number;
+    change: number;
+    changePercent: number;
+  } | null;
+  topPagesByQueryCount: PageQueryCount[] | null;
+}
+
+const POSITION_GROUPS = ["1-3", "4-10", "11-20", "21-50", "51+"] as const;
+
+function positionGroup(position: number): string {
+  if (position <= 3) return "1-3";
+  if (position <= 10) return "4-10";
+  if (position <= 20) return "11-20";
+  if (position <= 50) return "21-50";
+  return "51+";
+}
+
+export async function queryCount(
+  days: number = 28,
+  comparePrevious: boolean = true,
+  includePages: boolean = false,
+  topPages: number = 25,
+  searchType: SearchType = "web"
+): Promise<QueryCountResult> {
+  assertValidDimensions(searchType, ["query"]);
+  const { startDate, endDate } = getDateRange(days);
+
+  const queryRows = await fetchAllRows({
+    startDate,
+    endDate,
+    dimensions: ["query"],
+    searchType,
+  });
+
+  // Site totals without the query dimension. Grouping by date keeps the request
+  // small while still summing to the same figure the GSC dashboard shows.
+  const dateRows = await fetchAllRows({
+    startDate,
+    endDate,
+    dimensions: ["date"],
+    searchType,
+  });
+
+  const clicksFromVisibleQueries = queryRows.reduce((sum, r) => sum + r.clicks, 0);
+  const totalClicks = dateRows.reduce((sum, r) => sum + r.clicks, 0);
+  const anonymizedClicks = Math.max(0, totalClicks - clicksFromVisibleQueries);
+
+  const buckets = new Map<string, { queries: number; clicks: number; impressions: number }>();
+  for (const group of POSITION_GROUPS) {
+    buckets.set(group, { queries: 0, clicks: 0, impressions: 0 });
+  }
+  for (const row of queryRows) {
+    const bucket = buckets.get(positionGroup(row.position))!;
+    bucket.queries += 1;
+    bucket.clicks += row.clicks;
+    bucket.impressions += row.impressions;
+  }
+
+  const visibleQueries = queryRows.length;
+  const byPositionGroup: PositionGroupCount[] = POSITION_GROUPS.map((group) => {
+    const bucket = buckets.get(group)!;
+    return {
+      group,
+      queries: bucket.queries,
+      clicks: bucket.clicks,
+      impressions: bucket.impressions,
+      queryShare:
+        visibleQueries > 0 ? Math.round((bucket.queries / visibleQueries) * 10000) / 100 : 0,
+    };
+  });
+
+  let previousPeriod: QueryCountResult["previousPeriod"] = null;
+  if (comparePrevious) {
+    const prior = getPriorDateRange(days);
+    const priorRows = await fetchAllRows({
+      startDate: prior.startDate,
+      endDate: prior.endDate,
+      dimensions: ["query"],
+      searchType,
+    });
+    const change = visibleQueries - priorRows.length;
+    previousPeriod = {
+      startDate: prior.startDate,
+      endDate: prior.endDate,
+      visibleQueries: priorRows.length,
+      change,
+      changePercent:
+        priorRows.length > 0 ? Math.round((change / priorRows.length) * 10000) / 100 : 0,
+    };
+  }
+
+  let topPagesByQueryCount: PageQueryCount[] | null = null;
+  if (includePages) {
+    assertValidDimensions(searchType, ["page", "query"]);
+    const pageQueryRows = await fetchAllRows({
+      startDate,
+      endDate,
+      dimensions: ["page", "query"],
+      searchType,
+      maxRows: 100000,
+    });
+
+    const pages = new Map<string, { queries: number; clicks: number; impressions: number }>();
+    for (const row of pageQueryRows) {
+      const page = row.keys[0];
+      const entry = pages.get(page) || { queries: 0, clicks: 0, impressions: 0 };
+      entry.queries += 1;
+      entry.clicks += row.clicks;
+      entry.impressions += row.impressions;
+      pages.set(page, entry);
+    }
+
+    topPagesByQueryCount = [...pages.entries()]
+      .map(([page, entry]) => ({ page, ...entry }))
+      .sort((a, b) => b.queries - a.queries)
+      .slice(0, topPages);
+  }
+
+  return {
+    period: { startDate, endDate, days },
+    totals: {
+      visibleQueries,
+      clicksFromVisibleQueries,
+      totalClicks,
+      anonymizedClicks,
+      anonymizedClicksShare:
+        totalClicks > 0 ? Math.round((anonymizedClicks / totalClicks) * 10000) / 100 : 0,
+    },
+    byPositionGroup,
+    previousPeriod,
+    topPagesByQueryCount,
+  };
+}

--- a/src/tools/query-count.ts
+++ b/src/tools/query-count.ts
@@ -4,17 +4,25 @@ import {
   getPriorDateRange,
   SearchType,
   assertValidDimensions,
+  QueryParams,
 } from "../analytics.js";
 
 /**
- * Query counting: how many distinct queries a site (and each page) is visible
- * for, split by position group.
+ * Query counting: how many distinct queries a property, a section or a single
+ * URL is visible for - split by position group, optionally as a time series.
  *
- * The number GSC hands back is a FLOOR, not the truth: queries below Google's
- * privacy threshold never appear as rows, so their clicks show up in the site
- * total but in no query row. We therefore also report that gap explicitly
- * instead of pretending the query table is complete.
+ * The count GSC hands back is a FLOOR, not the truth: queries below Google's
+ * privacy threshold never appear as rows, so their clicks land in the totals
+ * but in no query row. That gap is reported explicitly instead of leaving the
+ * query table to be mistaken for the complete keyword set.
+ *
+ * Time series buckets are fetched one request per bucket. That is deliberate:
+ * the API de-duplicates queries within the requested range, so a per-bucket
+ * request yields an exact distinct count without holding every query string
+ * of every day in memory.
  */
+
+export type Granularity = "none" | "day" | "week" | "month";
 
 interface PositionGroupCount {
   group: string;
@@ -31,8 +39,23 @@ interface PageQueryCount {
   impressions: number;
 }
 
+interface Bucket {
+  startDate: string;
+  endDate: string;
+  visibleQueries: number;
+  clicks: number;
+  impressions: number;
+}
+
 interface QueryCountResult {
   period: { startDate: string; endDate: string; days: number };
+  scope: {
+    url: string | null;
+    urlContains: string | null;
+    surface: SearchType;
+    minPosition: number | null;
+    maxPosition: number | null;
+  };
   totals: {
     visibleQueries: number;
     clicksFromVisibleQueries: number;
@@ -40,7 +63,9 @@ interface QueryCountResult {
     anonymizedClicks: number;
     anonymizedClicksShare: number;
   };
+  filtered: { visibleQueries: number; clicks: number; impressions: number } | null;
   byPositionGroup: PositionGroupCount[];
+  timeSeries: Bucket[] | null;
   previousPeriod: {
     startDate: string;
     endDate: string;
@@ -61,93 +86,191 @@ function positionGroup(position: number): string {
   return "51+";
 }
 
+function parseISO(date: string): Date {
+  const [y, m, d] = date.split("-").map(Number);
+  return new Date(Date.UTC(y, m - 1, d));
+}
+
+function toISO(date: Date): string {
+  return date.toISOString().split("T")[0];
+}
+
+/** Splits a date range into day, ISO-week (Mon-Sun) or calendar-month buckets. */
+function buildBuckets(
+  startDate: string,
+  endDate: string,
+  granularity: Exclude<Granularity, "none">
+): Array<{ startDate: string; endDate: string }> {
+  const end = parseISO(endDate);
+  const out: Array<{ startDate: string; endDate: string }> = [];
+  let cursor = parseISO(startDate);
+
+  while (cursor <= end) {
+    let bucketEnd: Date;
+    if (granularity === "day") {
+      bucketEnd = new Date(cursor);
+    } else if (granularity === "week") {
+      const mondayOffset = (cursor.getUTCDay() + 6) % 7; // 0 = Monday
+      bucketEnd = new Date(cursor);
+      bucketEnd.setUTCDate(bucketEnd.getUTCDate() + (6 - mondayOffset));
+    } else {
+      bucketEnd = new Date(Date.UTC(cursor.getUTCFullYear(), cursor.getUTCMonth() + 1, 0));
+    }
+    if (bucketEnd > end) bucketEnd = new Date(end);
+
+    out.push({ startDate: toISO(cursor), endDate: toISO(bucketEnd) });
+    cursor = new Date(bucketEnd);
+    cursor.setUTCDate(cursor.getUTCDate() + 1);
+  }
+
+  return out;
+}
+
 export async function queryCount(
   days: number = 28,
   comparePrevious: boolean = true,
   includePages: boolean = false,
   topPages: number = 25,
-  searchType: SearchType = "web"
+  surface: SearchType = "web",
+  url?: string,
+  urlContains?: string,
+  granularity: Granularity = "none",
+  minPosition?: number,
+  maxPosition?: number
 ): Promise<QueryCountResult> {
-  assertValidDimensions(searchType, ["query"]);
+  assertValidDimensions(surface, ["query"]);
+
+  if (granularity === "day" && days > 90) {
+    throw new Error(
+      `granularity "day" over ${days} days would need ${days}+ API requests. ` +
+        `Use "week" or "month" for ranges beyond 90 days.`
+    );
+  }
+
   const { startDate, endDate } = getDateRange(days);
 
-  const queryRows = await fetchAllRows({
-    startDate,
-    endDate,
-    dimensions: ["query"],
-    searchType,
+  const pageFilters = [];
+  if (url) pageFilters.push({ dimension: "page", operator: "equals", expression: url });
+  if (urlContains)
+    pageFilters.push({ dimension: "page", operator: "contains", expression: urlContains });
+  const dimensionFilterGroups = pageFilters.length ? [{ filters: pageFilters }] : undefined;
+
+  const scoped = (params: Omit<QueryParams, "dimensionFilterGroups">): QueryParams => ({
+    ...params,
+    dimensionFilterGroups,
   });
 
-  // Site totals without the query dimension. Grouping by date keeps the request
-  // small while still summing to the same figure the GSC dashboard shows.
-  const dateRows = await fetchAllRows({
-    startDate,
-    endDate,
-    dimensions: ["date"],
-    searchType,
-  });
+  const queryRows = await fetchAllRows(
+    scoped({ startDate, endDate, dimensions: ["query"], searchType: surface })
+  );
+
+  // Totals without the query dimension: same scope, but including the clicks
+  // that no visible query row accounts for.
+  const dateRows = await fetchAllRows(
+    scoped({ startDate, endDate, dimensions: ["date"], searchType: surface })
+  );
 
   const clicksFromVisibleQueries = queryRows.reduce((sum, r) => sum + r.clicks, 0);
   const totalClicks = dateRows.reduce((sum, r) => sum + r.clicks, 0);
   const anonymizedClicks = Math.max(0, totalClicks - clicksFromVisibleQueries);
 
-  const buckets = new Map<string, { queries: number; clicks: number; impressions: number }>();
+  // The position filter narrows what gets counted, but never the gap above:
+  // that one only makes sense against the unfiltered scope.
+  const inPositionFilter = (position: number) =>
+    (minPosition === undefined || position >= minPosition) &&
+    (maxPosition === undefined || position <= maxPosition);
+  const hasPositionFilter = minPosition !== undefined || maxPosition !== undefined;
+  const countedRows = hasPositionFilter
+    ? queryRows.filter((r) => inPositionFilter(r.position))
+    : queryRows;
+
+  const groups = new Map<string, { queries: number; clicks: number; impressions: number }>();
   for (const group of POSITION_GROUPS) {
-    buckets.set(group, { queries: 0, clicks: 0, impressions: 0 });
+    groups.set(group, { queries: 0, clicks: 0, impressions: 0 });
   }
-  for (const row of queryRows) {
-    const bucket = buckets.get(positionGroup(row.position))!;
-    bucket.queries += 1;
-    bucket.clicks += row.clicks;
-    bucket.impressions += row.impressions;
+  for (const row of countedRows) {
+    const entry = groups.get(positionGroup(row.position))!;
+    entry.queries += 1;
+    entry.clicks += row.clicks;
+    entry.impressions += row.impressions;
   }
 
-  const visibleQueries = queryRows.length;
+  const countedTotal = countedRows.length;
   const byPositionGroup: PositionGroupCount[] = POSITION_GROUPS.map((group) => {
-    const bucket = buckets.get(group)!;
+    const entry = groups.get(group)!;
     return {
       group,
-      queries: bucket.queries,
-      clicks: bucket.clicks,
-      impressions: bucket.impressions,
+      queries: entry.queries,
+      clicks: entry.clicks,
+      impressions: entry.impressions,
       queryShare:
-        visibleQueries > 0 ? Math.round((bucket.queries / visibleQueries) * 10000) / 100 : 0,
+        countedTotal > 0 ? Math.round((entry.queries / countedTotal) * 10000) / 100 : 0,
     };
   });
+
+  let timeSeries: Bucket[] | null = null;
+  if (granularity !== "none") {
+    timeSeries = [];
+    for (const bucket of buildBuckets(startDate, endDate, granularity)) {
+      const rows = await fetchAllRows(
+        scoped({
+          startDate: bucket.startDate,
+          endDate: bucket.endDate,
+          dimensions: ["query"],
+          searchType: surface,
+        })
+      );
+      const counted = hasPositionFilter ? rows.filter((r) => inPositionFilter(r.position)) : rows;
+      timeSeries.push({
+        startDate: bucket.startDate,
+        endDate: bucket.endDate,
+        visibleQueries: counted.length,
+        clicks: counted.reduce((sum, r) => sum + r.clicks, 0),
+        impressions: counted.reduce((sum, r) => sum + r.impressions, 0),
+      });
+    }
+  }
 
   let previousPeriod: QueryCountResult["previousPeriod"] = null;
   if (comparePrevious) {
     const prior = getPriorDateRange(days);
-    const priorRows = await fetchAllRows({
-      startDate: prior.startDate,
-      endDate: prior.endDate,
-      dimensions: ["query"],
-      searchType,
-    });
-    const change = visibleQueries - priorRows.length;
+    const priorRows = await fetchAllRows(
+      scoped({
+        startDate: prior.startDate,
+        endDate: prior.endDate,
+        dimensions: ["query"],
+        searchType: surface,
+      })
+    );
+    const priorCount = (
+      hasPositionFilter ? priorRows.filter((r) => inPositionFilter(r.position)) : priorRows
+    ).length;
+    const change = countedTotal - priorCount;
     previousPeriod = {
       startDate: prior.startDate,
       endDate: prior.endDate,
-      visibleQueries: priorRows.length,
+      visibleQueries: priorCount,
       change,
-      changePercent:
-        priorRows.length > 0 ? Math.round((change / priorRows.length) * 10000) / 100 : 0,
+      changePercent: priorCount > 0 ? Math.round((change / priorCount) * 10000) / 100 : 0,
     };
   }
 
   let topPagesByQueryCount: PageQueryCount[] | null = null;
   if (includePages) {
-    assertValidDimensions(searchType, ["page", "query"]);
-    const pageQueryRows = await fetchAllRows({
-      startDate,
-      endDate,
-      dimensions: ["page", "query"],
-      searchType,
-      maxRows: 100000,
-    });
+    assertValidDimensions(surface, ["page", "query"]);
+    const pageQueryRows = await fetchAllRows(
+      scoped({
+        startDate,
+        endDate,
+        dimensions: ["page", "query"],
+        searchType: surface,
+        maxRows: 100000,
+      })
+    );
 
     const pages = new Map<string, { queries: number; clicks: number; impressions: number }>();
     for (const row of pageQueryRows) {
+      if (hasPositionFilter && !inPositionFilter(row.position)) continue;
       const page = row.keys[0];
       const entry = pages.get(page) || { queries: 0, clicks: 0, impressions: 0 };
       entry.queries += 1;
@@ -164,15 +287,30 @@ export async function queryCount(
 
   return {
     period: { startDate, endDate, days },
+    scope: {
+      url: url ?? null,
+      urlContains: urlContains ?? null,
+      surface,
+      minPosition: minPosition ?? null,
+      maxPosition: maxPosition ?? null,
+    },
     totals: {
-      visibleQueries,
+      visibleQueries: queryRows.length,
       clicksFromVisibleQueries,
       totalClicks,
       anonymizedClicks,
       anonymizedClicksShare:
         totalClicks > 0 ? Math.round((anonymizedClicks / totalClicks) * 10000) / 100 : 0,
     },
+    filtered: hasPositionFilter
+      ? {
+          visibleQueries: countedTotal,
+          clicks: countedRows.reduce((sum, r) => sum + r.clicks, 0),
+          impressions: countedRows.reduce((sum, r) => sum + r.impressions, 0),
+        }
+      : null,
     byPositionGroup,
+    timeSeries,
     previousPeriod,
     topPagesByQueryCount,
   };

--- a/src/tools/query-count.ts
+++ b/src/tools/query-count.ts
@@ -5,6 +5,7 @@ import {
   SearchType,
   assertValidDimensions,
   QueryParams,
+  deviceCountryFilters,
 } from "../analytics.js";
 
 /**
@@ -55,6 +56,8 @@ interface QueryCountResult {
     surface: SearchType;
     minPosition: number | null;
     maxPosition: number | null;
+    device: string | null;
+    country: string | null;
   };
   totals: {
     visibleQueries: number;
@@ -74,6 +77,7 @@ interface QueryCountResult {
     changePercent: number;
   } | null;
   topPagesByQueryCount: PageQueryCount[] | null;
+  comparabilityWarning: string | null;
 }
 
 const POSITION_GROUPS = ["1-3", "4-10", "11-20", "21-50", "51+"] as const;
@@ -136,7 +140,9 @@ export async function queryCount(
   urlContains?: string,
   granularity: Granularity = "none",
   minPosition?: number,
-  maxPosition?: number
+  maxPosition?: number,
+  device?: string,
+  country?: string
 ): Promise<QueryCountResult> {
   assertValidDimensions(surface, ["query"]);
 
@@ -153,6 +159,7 @@ export async function queryCount(
   if (url) pageFilters.push({ dimension: "page", operator: "equals", expression: url });
   if (urlContains)
     pageFilters.push({ dimension: "page", operator: "contains", expression: urlContains });
+  pageFilters.push(...deviceCountryFilters(device, country, surface));
   const dimensionFilterGroups = pageFilters.length ? [{ filters: pageFilters }] : undefined;
 
   const scoped = (params: Omit<QueryParams, "dimensionFilterGroups">): QueryParams => ({
@@ -293,6 +300,8 @@ export async function queryCount(
       surface,
       minPosition: minPosition ?? null,
       maxPosition: maxPosition ?? null,
+      device: device ? device.toUpperCase() : null,
+      country: country ? country.toLowerCase() : null,
     },
     totals: {
       visibleQueries: queryRows.length,
@@ -313,5 +322,15 @@ export async function queryCount(
     timeSeries,
     previousPeriod,
     topPagesByQueryCount,
+    // Measured against a live property: the API returns MORE query rows for a
+    // single device slice than for the unfiltered call over the same period
+    // (38,586 unfiltered vs 80,531 for MOBILE alone). Clicks stay consistent,
+    // so the filter itself is fine - the API simply surfaces more queries once
+    // the request is narrowed. Counts are therefore comparable only between
+    // runs with the SAME filter, never between filtered and unfiltered.
+    comparabilityWarning:
+      device || country
+        ? "A device or country filter is active. The API returns more query rows for a narrowed request than for the unfiltered one over the same period, so visibleQueries here is NOT comparable to an unfiltered run or to a run with a different filter - only to runs with this exact filter. Clicks and impressions are unaffected. For counts that stay comparable across slices, use the BigQuery bulk export (gsc_query_count in the BigQuery MCP), which does not truncate."
+        : null,
   };
 }

--- a/src/tools/quick-wins.ts
+++ b/src/tools/quick-wins.ts
@@ -1,4 +1,4 @@
-import { fetchAllRows, getDateRange } from "../analytics.js";
+import { fetchAllRows, getDateRange, SearchType, assertValidDimensions } from "../analytics.js";
 
 interface QuickWin {
   query: string;
@@ -21,14 +21,17 @@ function expectedCtrAtPosition(pos: number): number {
 export async function quickWins(
   days: number = 28,
   minImpressions: number = 100,
-  maxPosition: number = 15
+  maxPosition: number = 15,
+  searchType: SearchType = "web"
 ): Promise<QuickWin[]> {
+  assertValidDimensions(searchType, ["query"]);
   const { startDate, endDate } = getDateRange(days);
 
   const rows = await fetchAllRows({
     startDate,
     endDate,
     dimensions: ["query"],
+    searchType,
   });
 
   const wins: QuickWin[] = [];

--- a/src/tools/quick-wins.ts
+++ b/src/tools/quick-wins.ts
@@ -1,4 +1,10 @@
-import { fetchAllRows, getDateRange, SearchType, assertValidDimensions } from "../analytics.js";
+import {
+  fetchAllRows,
+  getDateRange,
+  SearchType,
+  assertValidDimensions,
+  deviceCountryFilters,
+} from "../analytics.js";
 
 interface QuickWin {
   query: string;
@@ -22,12 +28,17 @@ export async function quickWins(
   days: number = 28,
   minImpressions: number = 100,
   maxPosition: number = 15,
-  searchType: SearchType = "web"
+  searchType: SearchType = "web",
+  device?: string,
+  country?: string
 ): Promise<QuickWin[]> {
   assertValidDimensions(searchType, ["query"]);
   const { startDate, endDate } = getDateRange(days);
+  const extra = deviceCountryFilters(device, country, searchType);
+  const dimensionFilterGroups = extra.length ? [{ filters: extra }] : undefined;
 
   const rows = await fetchAllRows({
+    dimensionFilterGroups,
     startDate,
     endDate,
     dimensions: ["query"],

--- a/src/tools/search-appearance.ts
+++ b/src/tools/search-appearance.ts
@@ -1,0 +1,120 @@
+import { fetchAllRows, getDateRange, SearchType } from "../analytics.js";
+
+interface AppearanceRow {
+  appearance: string;
+  clicks: number;
+  impressions: number;
+  ctr: number;
+  position: number;
+}
+
+interface DrillRow {
+  key: string;
+  clicks: number;
+  impressions: number;
+  ctr: number;
+  position: number;
+}
+
+interface SearchAppearanceResult {
+  surface: SearchType;
+  mode: "breakdown" | "drilldown";
+  period: { startDate: string; endDate: string };
+  appearanceBreakdown: AppearanceRow[];
+  drilldown?: {
+    appearance: string;
+    dimension: "page" | "query";
+    rows: DrillRow[];
+  };
+  note: string;
+}
+
+/**
+ * Search-appearance breakdown (rich-result / feature types). Common values include
+ * MERCHANT_LISTINGS (Händlereinträge), PRODUCT_SNIPPETS, REVIEW_SNIPPET,
+ * RECIPE_FEATURE, VIDEO, AMP_* and others — the exact set is whatever the property
+ * is eligible for. The API requires searchAppearance to be queried alone, so to see
+ * which pages/queries drive a given appearance you must filter on it (drilldown).
+ *
+ * @param appearance Optional. If provided, drills into that appearance type and
+ *                   returns the top pages (or queries) driving it.
+ */
+export async function searchAppearance(
+  days: number = 28,
+  appearance?: string,
+  drillDimension: "page" | "query" = "page",
+  searchType: SearchType = "web",
+  rowLimit: number = 50,
+  siteUrl?: string
+): Promise<SearchAppearanceResult> {
+  const period = getDateRange(days);
+
+  // Step 1: always fetch the full appearance breakdown (searchAppearance alone).
+  const breakdownRows = await fetchAllRows(
+    {
+      startDate: period.startDate,
+      endDate: period.endDate,
+      dimensions: ["searchAppearance"],
+      searchType,
+    },
+    siteUrl
+  );
+
+  const appearanceBreakdown: AppearanceRow[] = breakdownRows
+    .sort((a, b) => b.impressions - a.impressions)
+    .map((r) => ({
+      appearance: r.keys[0],
+      clicks: r.clicks,
+      impressions: r.impressions,
+      ctr: Math.round(r.ctr * 10000) / 100,
+      position: Math.round(r.position * 10) / 10,
+    }));
+
+  let drilldown: SearchAppearanceResult["drilldown"];
+
+  // Step 2: optional drilldown — filter on the appearance, group by page/query.
+  if (appearance) {
+    const drillRows = await fetchAllRows(
+      {
+        startDate: period.startDate,
+        endDate: period.endDate,
+        dimensions: [drillDimension],
+        searchType,
+        dimensionFilterGroups: [
+          {
+            filters: [
+              { dimension: "searchAppearance", operator: "equals", expression: appearance },
+            ],
+          },
+        ],
+      },
+      siteUrl
+    );
+
+    drilldown = {
+      appearance,
+      dimension: drillDimension,
+      rows: drillRows
+        .sort((a, b) => b.clicks - a.clicks)
+        .slice(0, Math.min(rowLimit, 200))
+        .map((r) => ({
+          key: r.keys[0],
+          clicks: r.clicks,
+          impressions: r.impressions,
+          ctr: Math.round(r.ctr * 10000) / 100,
+          position: Math.round(r.position * 10) / 10,
+        })),
+    };
+  }
+
+  return {
+    surface: searchType,
+    mode: appearance ? "drilldown" : "breakdown",
+    period,
+    appearanceBreakdown,
+    drilldown,
+    note: appearance
+      ? `Top ${drilldown?.dimension ?? "page"}s for appearance "${appearance}". Filtered via dimensionFilterGroups.`
+      : "Appearance-type breakdown. Pass an `appearance` value (e.g. MERCHANT_LISTINGS) to drill into the pages or queries driving it.",
+  };
+}

--- a/src/tools/topic-cluster-performance.ts
+++ b/src/tools/topic-cluster-performance.ts
@@ -1,4 +1,4 @@
-import { fetchAllRows, getDateRange } from "../analytics.js";
+import { fetchAllRows, getDateRange, SearchType, ALLOWED_DIMENSIONS } from "../analytics.js";
 
 interface ClusterPerformance {
   pathPattern: string;
@@ -13,15 +13,18 @@ interface ClusterPerformance {
 
 export async function topicClusterPerformance(
   pathPattern: string,
-  days: number = 28
+  days: number = 28,
+  searchType: SearchType = "web"
 ): Promise<ClusterPerformance> {
   const { startDate, endDate } = getDateRange(days);
+  const supportsQuery = ALLOWED_DIMENSIONS[searchType].includes("query");
 
   // Fetch page-level data filtered by URL pattern
   const pageRows = await fetchAllRows({
     startDate,
     endDate,
     dimensions: ["page"],
+    searchType,
     dimensionFilterGroups: [
       {
         filters: [
@@ -35,23 +38,27 @@ export async function topicClusterPerformance(
     ],
   });
 
-  // Fetch query-level data filtered by URL pattern
-  const queryRows = await fetchAllRows({
-    startDate,
-    endDate,
-    dimensions: ["query"],
-    dimensionFilterGroups: [
-      {
-        filters: [
+  // Fetch query-level data filtered by URL pattern.
+  // Surfaces like Discover have no query dimension, so skip it there.
+  const queryRows = supportsQuery
+    ? await fetchAllRows({
+        startDate,
+        endDate,
+        dimensions: ["query"],
+        searchType,
+        dimensionFilterGroups: [
           {
-            dimension: "page",
-            operator: "contains",
-            expression: pathPattern,
+            filters: [
+              {
+                dimension: "page",
+                operator: "contains",
+                expression: pathPattern,
+              },
+            ],
           },
         ],
-      },
-    ],
-  });
+      })
+    : [];
 
   let totalClicks = 0;
   let totalImpressions = 0;

--- a/src/tools/traffic-drops.ts
+++ b/src/tools/traffic-drops.ts
@@ -1,4 +1,4 @@
-import { fetchAllRows, getDateRange, getPriorDateRange } from "../analytics.js";
+import { fetchAllRows, getDateRange, getPriorDateRange, SearchType, assertValidDimensions } from "../analytics.js";
 
 interface TrafficDrop {
   page: string;
@@ -11,13 +11,17 @@ interface TrafficDrop {
   diagnosis: string;
 }
 
-export async function trafficDrops(days: number = 28): Promise<TrafficDrop[]> {
+export async function trafficDrops(
+  days: number = 28,
+  searchType: SearchType = "web"
+): Promise<TrafficDrop[]> {
+  assertValidDimensions(searchType, ["page"]);
   const current = getDateRange(days);
   const prior = getPriorDateRange(days);
 
   const [currentRows, priorRows] = await Promise.all([
-    fetchAllRows({ startDate: current.startDate, endDate: current.endDate, dimensions: ["page"] }),
-    fetchAllRows({ startDate: prior.startDate, endDate: prior.endDate, dimensions: ["page"] }),
+    fetchAllRows({ startDate: current.startDate, endDate: current.endDate, dimensions: ["page"], searchType }),
+    fetchAllRows({ startDate: prior.startDate, endDate: prior.endDate, dimensions: ["page"], searchType }),
   ]);
 
   const priorMap = new Map<string, { clicks: number; position: number; ctr: number }>();

--- a/src/tools/verify-claim.ts
+++ b/src/tools/verify-claim.ts
@@ -1,4 +1,4 @@
-import { fetchAllRows, getDateRange } from "../analytics.js";
+import { fetchAllRows, getDateRange, SearchType, assertValidDimensions } from "../analytics.js";
 
 interface VerificationResult {
   claim: string;
@@ -22,7 +22,8 @@ export async function verifyClaim(
   expectedValue: number,
   url?: string,
   query?: string,
-  days: number = 28
+  days: number = 28,
+  searchType: SearchType = "web"
 ): Promise<VerificationResult> {
   const { startDate, endDate } = getDateRange(days);
 
@@ -51,10 +52,14 @@ export async function verifyClaim(
     });
   }
 
+  const effectiveDimensions = dimensions.length > 0 ? dimensions : ["date"];
+  assertValidDimensions(searchType, effectiveDimensions);
+
   const rows = await fetchAllRows({
     startDate,
     endDate,
-    dimensions: dimensions.length > 0 ? dimensions : ["date"],
+    dimensions: effectiveDimensions,
+    searchType,
     dimensionFilterGroups: filters.length > 0 ? filters : undefined,
   });
 


### PR DESCRIPTION
# Support Discover, Image, Video, News and search-appearance surfaces

## Why

The Search Analytics request in `analytics.ts` never set the API's `type`
field, which defaults to `web`. As a result **every tool only ever returned
web-search data** — Google Discover, Image, Video/News and the
`searchAppearance` dimension (merchant listings, product snippets, review
snippets, etc.) were unreachable through the server.

## What changed

**Core (`analytics.ts`)**
- Added the `SearchType` type (`web | image | video | news | discover | googleNews`) and threaded `type` into the `searchanalytics.query` request.
- Added `ALLOWED_DIMENSIONS` + `assertValidDimensions()`. Invalid combinations (e.g. `query` on Discover, or `searchAppearance` mixed with other grouping dimensions) now fail with a clear, actionable message instead of an opaque API 400 or a silent fallback to web data.

**New isolated tools**
- `discover_analysis` — `type=discover`. Top pages, country split and a daily clicks/impressions trend with prior-period comparison. No query/position (Discover is feed-based).
- `image_analysis` — `type=image`. Top image queries, top pages, prior-period comparison.
- `search_appearance` — breakdown by appearance type; pass an `appearance` value (e.g. `MERCHANT_LISTINGS`) to drill into the pages or queries driving it. Handles the API rule that `searchAppearance` must be queried alone, then filtered for drilldown.

**Existing tools gain an optional `surface` parameter** (default `"web"`, fully backwards compatible): `quick_wins`, `ctr_opportunities`, `traffic_drops`, `content_gaps`, `cannibalization_check`, `content_decay`, `ctr_vs_benchmark`, `topic_cluster_performance`, `verify_claim`, `advanced_search_analytics`, `check_alerts`.
- Query-based tools reject `discover` (no query dimension) via the guard.
- `topic_cluster_performance` automatically skips the query fetch on query-less surfaces and returns page-level data only.

Bumps version to **2.3.0** (23 tools).

## Compatibility

No breaking changes. `surface` defaults to `web` everywhere, so existing
calls behave exactly as before.

## Testing

- `tsc` compiles clean.
- `assertValidDimensions` verified across surface/dimension combinations
  (web+query OK, discover+page OK, discover+query throws, image+query+page OK,
  searchAppearance+page throws, discover+page/country/date OK).
