### PR TITLE
Add discover_analysis, search_appearance, query_count and a dimension guard

### DIFF
--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -1,5 +1,96 @@
 import { getSearchConsoleClient, getConfig } from "./auth.js";
 
+/**
+ * GSC search types, i.e. the values the Search Analytics `type` filter takes.
+ * The API defaults to "web" when the field is omitted.
+ */
+export type SearchType = "web" | "image" | "video" | "news" | "discover" | "googleNews";
+
+/**
+ * Dimensions the API actually allows per search type. Used by
+ * assertValidDimensions() so an illegal combination fails with a clear message
+ * instead of the API's opaque 400.
+ *
+ * searchAppearance is listed here but is special: the API requires it to be the
+ * only grouping dimension, which the guard checks separately.
+ */
+export const ALLOWED_DIMENSIONS: Record<SearchType, string[]> = {
+  web: ["query", "page", "country", "device", "date", "searchAppearance"],
+  image: ["query", "page", "country", "device", "date", "searchAppearance"],
+  video: ["query", "page", "country", "device", "date", "searchAppearance"],
+  news: ["query", "page", "country", "device", "date"],
+  // Discover is feed-based, not query-based: no "query", and no "device" either.
+  discover: ["page", "country", "date", "searchAppearance"],
+  googleNews: ["page", "country", "date"],
+};
+
+/**
+ * Validates that the requested dimensions are legal for the chosen search type.
+ * Throws a descriptive error instead of letting the API return a generic 400
+ * that names neither the offending dimension nor the allowed set.
+ */
+export function assertValidDimensions(searchType: SearchType, dimensions: string[]): void {
+  const allowed = ALLOWED_DIMENSIONS[searchType];
+  const invalid = dimensions.filter((d) => !allowed.includes(d));
+  if (invalid.length > 0) {
+    throw new Error(
+      `Dimension(s) [${invalid.join(", ")}] are not supported for type "${searchType}". ` +
+        `Allowed: [${allowed.join(", ")}].`
+    );
+  }
+  if (dimensions.includes("searchAppearance") && dimensions.length > 1) {
+    throw new Error(
+      `"searchAppearance" must be the only grouping dimension. ` +
+        `To break a single appearance down by page or query, filter on searchAppearance instead.`
+    );
+  }
+}
+
+export const DEVICES = ["MOBILE", "DESKTOP", "TABLET"] as const;
+export type Device = (typeof DEVICES)[number];
+
+/**
+ * Builds the device and country dimension filters shared by the analysis tools.
+ * Both are opt-in: omitting them keeps the API default of all devices and all
+ * countries, so existing callers are unaffected.
+ *
+ * Discover carries no device dimension (see ALLOWED_DIMENSIONS), so filtering
+ * by device there is impossible rather than merely empty. That fails loudly.
+ */
+export function deviceCountryFilters(
+  device?: string,
+  country?: string,
+  searchType: SearchType = "web"
+): Array<{ dimension: string; operator: string; expression: string }> {
+  const filters: Array<{ dimension: string; operator: string; expression: string }> = [];
+
+  if (device) {
+    if (!ALLOWED_DIMENSIONS[searchType].includes("device")) {
+      throw new Error(
+        `type "${searchType}" has no device dimension, so it cannot be filtered by device. ` +
+          `Allowed dimensions: [${ALLOWED_DIMENSIONS[searchType].join(", ")}].`
+      );
+    }
+    const upper = device.toUpperCase() as Device;
+    if (!DEVICES.includes(upper)) {
+      throw new Error(`Unknown device "${device}". Allowed: ${DEVICES.join(", ")}.`);
+    }
+    filters.push({ dimension: "device", operator: "equals", expression: upper });
+  }
+
+  if (country) {
+    const lower = country.toLowerCase();
+    if (!/^[a-z]{3}$/.test(lower)) {
+      throw new Error(
+        `Country must be an ISO-3166-1 alpha-3 code such as deu, aut, che or usa - got "${country}".`
+      );
+    }
+    filters.push({ dimension: "country", operator: "equals", expression: lower });
+  }
+
+  return filters;
+}
+
 export interface SearchAnalyticsRow {
   keys: string[];
   clicks: number;
@@ -22,7 +113,9 @@ export interface QueryParams {
   rowLimit?: number;
   // GSC Search Analytics `type` filter. Values: web (default), image, video,
   // news, discover, googleNews. Added in v2.3 to unlock image-search data.
-  type?: "web" | "image" | "video" | "news" | "discover" | "googleNews";
+  type?: SearchType;
+  /** Hard cap on rows fetched across all pages. Omit for no cap. */
+  maxRows?: number;
 }
 
 function formatDate(date: Date): string {
@@ -99,8 +192,9 @@ export async function fetchAllRows(params: QueryParams, siteUrlOverride?: string
     }
 
     if (rows.length < pageSize) break;
+    if (params.maxRows && allRows.length >= params.maxRows) break;
     startRow += pageSize;
   }
 
-  return allRows;
+  return params.maxRows ? allRows.slice(0, params.maxRows) : allRows;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,11 +38,21 @@ import { genaiConversationQueries } from "./tools/genai-conversation-queries.js"
 // v2.5: the bridge from "which pages fail in image search" to "why". Fetches
 // the user's own pages and audits the on-page image factors.
 import { imagePageAudit } from "./tools/image-page-audit.js";
+// Surfaces the type filter reaches that the image suite does not cover:
+// Discover (feed-based, no queries) and the searchAppearance dimension.
+import { discoverAnalysis } from "./tools/discover-analysis.js";
+import { searchAppearance } from "./tools/search-appearance.js";
+import { queryCount } from "./tools/query-count.js";
 
 const server = new McpServer({
   name: "gsc-mcp",
   version: "2.5.1",
 });
+
+// Shared GSC surface (search type) parameter. "web" is the API default, so
+// every tool that takes it stays backwards-compatible when it is omitted.
+const SURFACES = ["web", "image", "video", "news", "discover", "googleNews"] as const;
+const surfaceParam = (note: string) => z.enum(SURFACES).default("web").describe(note);
 
 // 1. Quick Wins
 server.tool(
@@ -577,6 +587,72 @@ server.tool(
   }
 );
 
+
+// 30. Discover Analysis (isolated)
+server.tool(
+  "discover_analysis",
+  "Analyse Google Discover performance in isolation (type=discover). Discover is feed-based, not query-based, so this returns top pages, country split and a daily clicks/impressions trend with a prior-period comparison. No query-level data or position exists for Discover." + GUARDRAIL_SUFFIX + VISUAL_SUFFIX,
+  {
+    days: z.number().default(28).describe("Number of days per period to compare"),
+    row_limit: z.number().default(50).describe("Max number of top pages to return"),
+    site_url: z.string().optional().describe("Override the configured property"),
+  },
+  async ({ days, row_limit, site_url }) => {
+    const results = await discoverAnalysis(days, row_limit, site_url);
+    const wrapped = withMeta(results, "discover_analysis", { days, row_limit, site_url });
+    return {
+      content: [{ type: "text", text: JSON.stringify(wrapped, null, 2) }],
+    };
+  }
+);
+
+// 31. Search Appearance / rich-result types
+server.tool(
+  "search_appearance",
+  "Break down performance by search-appearance / rich-result type (the searchAppearance dimension), e.g. MERCHANT_LISTINGS, PRODUCT_SNIPPETS, REVIEW_SNIPPET, RECIPE_FEATURE. Without an appearance argument it lists all appearance types with their metrics. Pass an appearance value to drill into the pages or queries driving that specific type." + GUARDRAIL_SUFFIX + VISUAL_SUFFIX + POSITION_CAVEAT,
+  {
+    days: z.number().default(28).describe("Number of days to analyse"),
+    appearance: z.string().optional().describe("Appearance type to drill into, e.g. MERCHANT_LISTINGS. Omit for the full breakdown."),
+    drill_dimension: z.enum(["page", "query"]).default("page").describe("When drilling into an appearance, group by page or query"),
+    search_type: surfaceParam("Surface to query the appearance breakdown for"),
+    row_limit: z.number().default(50).describe("Max number of drilldown rows to return"),
+    site_url: z.string().optional().describe("Override the configured property"),
+  },
+  async ({ days, appearance, drill_dimension, search_type, row_limit, site_url }) => {
+    const results = await searchAppearance(days, appearance, drill_dimension, search_type, row_limit, site_url);
+    const wrapped = withMeta(results, "search_appearance", { days, appearance, drill_dimension, search_type, row_limit, site_url });
+    return {
+      content: [{ type: "text", text: JSON.stringify(wrapped, null, 2) }],
+    };
+  }
+);
+
+// 32. Query Counting
+server.tool(
+  "query_count",
+  "Count how many distinct queries a property, a section or a single URL is visible for, split by position group (1-3, 4-10, 11-20, 21-50, 51+). Scope it with url (one page) or url_contains (a path), turn it into a time series with granularity (day/week/month), and narrow it with min_position/max_position. Also reports the anonymized-click gap: clicks the totals contain but no query row explains, because those queries fall below Google's privacy threshold. The query count is a floor, never the complete keyword set." + GUARDRAIL_SUFFIX + VISUAL_SUFFIX + POSITION_CAVEAT,
+  {
+    days: z.number().default(28).describe("Number of days to analyse"),
+    url: z.string().optional().describe("Count only queries for this exact URL"),
+    url_contains: z.string().optional().describe("Count only queries for URLs containing this string, e.g. /blog/"),
+    granularity: z.enum(["none", "day", "week", "month"]).default("none").describe("Return a time series of query counts. One API request per bucket, so day-level is capped at 90 days."),
+    min_position: z.number().optional().describe("Only count queries at this average position or worse (e.g. 4)"),
+    max_position: z.number().optional().describe("Only count queries at this average position or better (e.g. 10)"),
+    compare_previous: z.boolean().default(true).describe("Also count the immediately preceding period of the same length"),
+    include_pages: z.boolean().default(false).describe("Also rank pages by query count. Expensive: needs the page+query dimension pair, capped at 100k rows."),
+    top_pages: z.number().default(25).describe("How many pages to return when include_pages is true"),
+    surface: surfaceParam("Surface to query: web (default), image, video, news. Discover is NOT supported here (no query dimension)."),
+    device: z.enum(["MOBILE", "DESKTOP", "TABLET"]).optional().describe("Restrict to one device. Omit for all devices, which is the default. Not available on Discover, which carries no device dimension."),
+    country: z.string().optional().describe("Restrict to one country as an ISO-3166-1 alpha-3 code, e.g. deu, usa, gbr. Omit for all countries, which is the default."),
+  },
+  async ({ days, url, url_contains, granularity, min_position, max_position, compare_previous, include_pages, top_pages, surface, device, country }) => {
+    const results = await queryCount(days, compare_previous, include_pages, top_pages, surface, url, url_contains, granularity, min_position, max_position, device, country);
+    const wrapped = withMeta(results, "query_count", { days, url, url_contains, granularity, min_position, max_position, compare_previous, include_pages, top_pages, surface, device, country });
+    return {
+      content: [{ type: "text", text: JSON.stringify(wrapped, null, 2) }],
+    };
+  }
+);
 async function main() {
   const cmd = process.argv[2];
   if (cmd === "setup") {

--- a/src/tools/advanced-search-analytics.ts
+++ b/src/tools/advanced-search-analytics.ts
@@ -1,4 +1,10 @@
-import { fetchAllRows, getDateRange, SearchAnalyticsRow } from "../analytics.js";
+import {
+  fetchAllRows,
+  getDateRange,
+  SearchAnalyticsRow,
+  SearchType,
+  assertValidDimensions,
+} from "../analytics.js";
 
 interface Filter {
   dimension: string;
@@ -28,8 +34,12 @@ export async function advancedSearchAnalytics(
   orderBy: string = "clicks",
   orderDirection: string = "descending",
   siteUrl?: string,
-  searchType?: "web" | "image" | "video" | "news" | "discover" | "googleNews"
+  searchType?: SearchType
 ): Promise<AdvancedSearchResult & { searchType: string }> {
+  // Fail with a message that names the offending dimension and the legal set,
+  // rather than passing an illegal combination through to the API's bare 400.
+  assertValidDimensions(searchType ?? "web", dimensions);
+
   const { startDate, endDate } = getDateRange(days);
 
   // Build dimension filter groups from user-provided filters

--- a/src/tools/discover-analysis.ts
+++ b/src/tools/discover-analysis.ts
@@ -1,0 +1,126 @@
+import {
+  fetchAllRows,
+  getDateRange,
+  getPriorDateRange,
+  assertValidDimensions,
+} from "../analytics.js";
+
+interface PeriodTotals {
+  clicks: number;
+  impressions: number;
+  ctr: number;
+}
+
+interface DiscoverPage {
+  page: string;
+  clicks: number;
+  impressions: number;
+  ctr: number;
+}
+
+interface DiscoverAnalysisResult {
+  surface: "discover";
+  period: { startDate: string; endDate: string };
+  totals: PeriodTotals;
+  change: { clicksPercent: number; impressionsPercent: number };
+  topPages: DiscoverPage[];
+  byCountry: Array<{ country: string; clicks: number; impressions: number; ctr: number }>;
+  dailyTrend: Array<{ date: string; clicks: number; impressions: number }>;
+  note: string;
+}
+
+function totals(rows: { clicks: number; impressions: number }[]): PeriodTotals {
+  let clicks = 0;
+  let impressions = 0;
+  for (const r of rows) {
+    clicks += r.clicks;
+    impressions += r.impressions;
+  }
+  return {
+    clicks,
+    impressions,
+    ctr: impressions > 0 ? Math.round((clicks / impressions) * 10000) / 100 : 0,
+  };
+}
+
+function pct(curr: number, prior: number): number {
+  return prior > 0 ? Math.round(((curr - prior) / prior) * 10000) / 100 : 0;
+}
+
+/**
+ * Isolated Google Discover performance. Discover is NOT query-based, so the API
+ * only supports page / country / date dimensions here. Position/CTR-vs-position
+ * benchmarks from web tools do not apply.
+ */
+export async function discoverAnalysis(
+  days: number = 28,
+  rowLimit: number = 50,
+  siteUrl?: string
+): Promise<DiscoverAnalysisResult> {
+  const current = getDateRange(days);
+  const prior = getPriorDateRange(days);
+
+  assertValidDimensions("discover", ["page"]);
+
+  const [pageRows, priorPageRows, countryRows, dateRows] = await Promise.all([
+    fetchAllRows(
+      { startDate: current.startDate, endDate: current.endDate, dimensions: ["page"], type: "discover" },
+      siteUrl
+    ),
+    fetchAllRows(
+      { startDate: prior.startDate, endDate: prior.endDate, dimensions: ["page"], type: "discover" },
+      siteUrl
+    ),
+    fetchAllRows(
+      { startDate: current.startDate, endDate: current.endDate, dimensions: ["country"], type: "discover" },
+      siteUrl
+    ),
+    fetchAllRows(
+      { startDate: current.startDate, endDate: current.endDate, dimensions: ["date"], type: "discover" },
+      siteUrl
+    ),
+  ]);
+
+  const curTotals = totals(pageRows);
+  const priorTotals = totals(priorPageRows);
+
+  const topPages = pageRows
+    .sort((a, b) => b.clicks - a.clicks)
+    .slice(0, Math.min(rowLimit, 200))
+    .map((r) => ({
+      page: r.keys[0],
+      clicks: r.clicks,
+      impressions: r.impressions,
+      ctr: Math.round(r.ctr * 10000) / 100,
+    }));
+
+  const byCountry = countryRows
+    .sort((a, b) => b.clicks - a.clicks)
+    .slice(0, 15)
+    .map((r) => ({
+      country: r.keys[0],
+      clicks: r.clicks,
+      impressions: r.impressions,
+      ctr: Math.round(r.ctr * 10000) / 100,
+    }));
+
+  const dailyTrend = dateRows
+    .sort((a, b) => a.keys[0].localeCompare(b.keys[0]))
+    .map((r) => ({ date: r.keys[0], clicks: r.clicks, impressions: r.impressions }));
+
+  return {
+    surface: "discover",
+    period: current,
+    totals: curTotals,
+    change: {
+      clicksPercent: pct(curTotals.clicks, priorTotals.clicks),
+      impressionsPercent: pct(curTotals.impressions, priorTotals.impressions),
+    },
+    topPages,
+    byCountry,
+    dailyTrend,
+    note:
+      "Google Discover is feed-based, not query-based. There are no query-level rows " +
+      "and average position is not meaningful here. Optimise on title, hero image and freshness.",
+  };
+}

--- a/src/tools/query-count.ts
+++ b/src/tools/query-count.ts
@@ -1,0 +1,336 @@
+import {
+  fetchAllRows,
+  getDateRange,
+  getPriorDateRange,
+  SearchType,
+  assertValidDimensions,
+  QueryParams,
+  deviceCountryFilters,
+} from "../analytics.js";
+
+/**
+ * Query counting: how many distinct queries a property, a section or a single
+ * URL is visible for - split by position group, optionally as a time series.
+ *
+ * The count GSC hands back is a FLOOR, not the truth: queries below Google's
+ * privacy threshold never appear as rows, so their clicks land in the totals
+ * but in no query row. That gap is reported explicitly instead of leaving the
+ * query table to be mistaken for the complete keyword set.
+ *
+ * Time series buckets are fetched one request per bucket. That is deliberate:
+ * the API de-duplicates queries within the requested range, so a per-bucket
+ * request yields an exact distinct count without holding every query string
+ * of every day in memory.
+ */
+
+export type Granularity = "none" | "day" | "week" | "month";
+
+interface PositionGroupCount {
+  group: string;
+  queries: number;
+  clicks: number;
+  impressions: number;
+  queryShare: number;
+}
+
+interface PageQueryCount {
+  page: string;
+  queries: number;
+  clicks: number;
+  impressions: number;
+}
+
+interface Bucket {
+  startDate: string;
+  endDate: string;
+  visibleQueries: number;
+  clicks: number;
+  impressions: number;
+}
+
+interface QueryCountResult {
+  period: { startDate: string; endDate: string; days: number };
+  scope: {
+    url: string | null;
+    urlContains: string | null;
+    surface: SearchType;
+    minPosition: number | null;
+    maxPosition: number | null;
+    device: string | null;
+    country: string | null;
+  };
+  totals: {
+    visibleQueries: number;
+    clicksFromVisibleQueries: number;
+    totalClicks: number;
+    anonymizedClicks: number;
+    anonymizedClicksShare: number;
+  };
+  filtered: { visibleQueries: number; clicks: number; impressions: number } | null;
+  byPositionGroup: PositionGroupCount[];
+  timeSeries: Bucket[] | null;
+  previousPeriod: {
+    startDate: string;
+    endDate: string;
+    visibleQueries: number;
+    change: number;
+    changePercent: number;
+  } | null;
+  topPagesByQueryCount: PageQueryCount[] | null;
+  comparabilityWarning: string | null;
+}
+
+const POSITION_GROUPS = ["1-3", "4-10", "11-20", "21-50", "51+"] as const;
+
+function positionGroup(position: number): string {
+  if (position <= 3) return "1-3";
+  if (position <= 10) return "4-10";
+  if (position <= 20) return "11-20";
+  if (position <= 50) return "21-50";
+  return "51+";
+}
+
+function parseISO(date: string): Date {
+  const [y, m, d] = date.split("-").map(Number);
+  return new Date(Date.UTC(y, m - 1, d));
+}
+
+function toISO(date: Date): string {
+  return date.toISOString().split("T")[0];
+}
+
+/** Splits a date range into day, ISO-week (Mon-Sun) or calendar-month buckets. */
+function buildBuckets(
+  startDate: string,
+  endDate: string,
+  granularity: Exclude<Granularity, "none">
+): Array<{ startDate: string; endDate: string }> {
+  const end = parseISO(endDate);
+  const out: Array<{ startDate: string; endDate: string }> = [];
+  let cursor = parseISO(startDate);
+
+  while (cursor <= end) {
+    let bucketEnd: Date;
+    if (granularity === "day") {
+      bucketEnd = new Date(cursor);
+    } else if (granularity === "week") {
+      const mondayOffset = (cursor.getUTCDay() + 6) % 7; // 0 = Monday
+      bucketEnd = new Date(cursor);
+      bucketEnd.setUTCDate(bucketEnd.getUTCDate() + (6 - mondayOffset));
+    } else {
+      bucketEnd = new Date(Date.UTC(cursor.getUTCFullYear(), cursor.getUTCMonth() + 1, 0));
+    }
+    if (bucketEnd > end) bucketEnd = new Date(end);
+
+    out.push({ startDate: toISO(cursor), endDate: toISO(bucketEnd) });
+    cursor = new Date(bucketEnd);
+    cursor.setUTCDate(cursor.getUTCDate() + 1);
+  }
+
+  return out;
+}
+
+export async function queryCount(
+  days: number = 28,
+  comparePrevious: boolean = true,
+  includePages: boolean = false,
+  topPages: number = 25,
+  surface: SearchType = "web",
+  url?: string,
+  urlContains?: string,
+  granularity: Granularity = "none",
+  minPosition?: number,
+  maxPosition?: number,
+  device?: string,
+  country?: string
+): Promise<QueryCountResult> {
+  assertValidDimensions(surface, ["query"]);
+
+  if (granularity === "day" && days > 90) {
+    throw new Error(
+      `granularity "day" over ${days} days would need ${days}+ API requests. ` +
+        `Use "week" or "month" for ranges beyond 90 days.`
+    );
+  }
+
+  const { startDate, endDate } = getDateRange(days);
+
+  const pageFilters = [];
+  if (url) pageFilters.push({ dimension: "page", operator: "equals", expression: url });
+  if (urlContains)
+    pageFilters.push({ dimension: "page", operator: "contains", expression: urlContains });
+  pageFilters.push(...deviceCountryFilters(device, country, surface));
+  const dimensionFilterGroups = pageFilters.length ? [{ filters: pageFilters }] : undefined;
+
+  const scoped = (params: Omit<QueryParams, "dimensionFilterGroups">): QueryParams => ({
+    ...params,
+    dimensionFilterGroups,
+  });
+
+  const queryRows = await fetchAllRows(
+    scoped({ startDate, endDate, dimensions: ["query"], type: surface })
+  );
+
+  // Totals without the query dimension: same scope, but including the clicks
+  // that no visible query row accounts for.
+  const dateRows = await fetchAllRows(
+    scoped({ startDate, endDate, dimensions: ["date"], type: surface })
+  );
+
+  const clicksFromVisibleQueries = queryRows.reduce((sum, r) => sum + r.clicks, 0);
+  const totalClicks = dateRows.reduce((sum, r) => sum + r.clicks, 0);
+  const anonymizedClicks = Math.max(0, totalClicks - clicksFromVisibleQueries);
+
+  // The position filter narrows what gets counted, but never the gap above:
+  // that one only makes sense against the unfiltered scope.
+  const inPositionFilter = (position: number) =>
+    (minPosition === undefined || position >= minPosition) &&
+    (maxPosition === undefined || position <= maxPosition);
+  const hasPositionFilter = minPosition !== undefined || maxPosition !== undefined;
+  const countedRows = hasPositionFilter
+    ? queryRows.filter((r) => inPositionFilter(r.position))
+    : queryRows;
+
+  const groups = new Map<string, { queries: number; clicks: number; impressions: number }>();
+  for (const group of POSITION_GROUPS) {
+    groups.set(group, { queries: 0, clicks: 0, impressions: 0 });
+  }
+  for (const row of countedRows) {
+    const entry = groups.get(positionGroup(row.position))!;
+    entry.queries += 1;
+    entry.clicks += row.clicks;
+    entry.impressions += row.impressions;
+  }
+
+  const countedTotal = countedRows.length;
+  const byPositionGroup: PositionGroupCount[] = POSITION_GROUPS.map((group) => {
+    const entry = groups.get(group)!;
+    return {
+      group,
+      queries: entry.queries,
+      clicks: entry.clicks,
+      impressions: entry.impressions,
+      queryShare:
+        countedTotal > 0 ? Math.round((entry.queries / countedTotal) * 10000) / 100 : 0,
+    };
+  });
+
+  let timeSeries: Bucket[] | null = null;
+  if (granularity !== "none") {
+    timeSeries = [];
+    for (const bucket of buildBuckets(startDate, endDate, granularity)) {
+      const rows = await fetchAllRows(
+        scoped({
+          startDate: bucket.startDate,
+          endDate: bucket.endDate,
+          dimensions: ["query"],
+          type: surface,
+        })
+      );
+      const counted = hasPositionFilter ? rows.filter((r) => inPositionFilter(r.position)) : rows;
+      timeSeries.push({
+        startDate: bucket.startDate,
+        endDate: bucket.endDate,
+        visibleQueries: counted.length,
+        clicks: counted.reduce((sum, r) => sum + r.clicks, 0),
+        impressions: counted.reduce((sum, r) => sum + r.impressions, 0),
+      });
+    }
+  }
+
+  let previousPeriod: QueryCountResult["previousPeriod"] = null;
+  if (comparePrevious) {
+    const prior = getPriorDateRange(days);
+    const priorRows = await fetchAllRows(
+      scoped({
+        startDate: prior.startDate,
+        endDate: prior.endDate,
+        dimensions: ["query"],
+        type: surface,
+      })
+    );
+    const priorCount = (
+      hasPositionFilter ? priorRows.filter((r) => inPositionFilter(r.position)) : priorRows
+    ).length;
+    const change = countedTotal - priorCount;
+    previousPeriod = {
+      startDate: prior.startDate,
+      endDate: prior.endDate,
+      visibleQueries: priorCount,
+      change,
+      changePercent: priorCount > 0 ? Math.round((change / priorCount) * 10000) / 100 : 0,
+    };
+  }
+
+  let topPagesByQueryCount: PageQueryCount[] | null = null;
+  if (includePages) {
+    assertValidDimensions(surface, ["page", "query"]);
+    const pageQueryRows = await fetchAllRows(
+      scoped({
+        startDate,
+        endDate,
+        dimensions: ["page", "query"],
+        type: surface,
+        maxRows: 100000,
+      })
+    );
+
+    const pages = new Map<string, { queries: number; clicks: number; impressions: number }>();
+    for (const row of pageQueryRows) {
+      if (hasPositionFilter && !inPositionFilter(row.position)) continue;
+      const page = row.keys[0];
+      const entry = pages.get(page) || { queries: 0, clicks: 0, impressions: 0 };
+      entry.queries += 1;
+      entry.clicks += row.clicks;
+      entry.impressions += row.impressions;
+      pages.set(page, entry);
+    }
+
+    topPagesByQueryCount = [...pages.entries()]
+      .map(([page, entry]) => ({ page, ...entry }))
+      .sort((a, b) => b.queries - a.queries)
+      .slice(0, topPages);
+  }
+
+  return {
+    period: { startDate, endDate, days },
+    scope: {
+      url: url ?? null,
+      urlContains: urlContains ?? null,
+      surface,
+      minPosition: minPosition ?? null,
+      maxPosition: maxPosition ?? null,
+      device: device ? device.toUpperCase() : null,
+      country: country ? country.toLowerCase() : null,
+    },
+    totals: {
+      visibleQueries: queryRows.length,
+      clicksFromVisibleQueries,
+      totalClicks,
+      anonymizedClicks,
+      anonymizedClicksShare:
+        totalClicks > 0 ? Math.round((anonymizedClicks / totalClicks) * 10000) / 100 : 0,
+    },
+    filtered: hasPositionFilter
+      ? {
+          visibleQueries: countedTotal,
+          clicks: countedRows.reduce((sum, r) => sum + r.clicks, 0),
+          impressions: countedRows.reduce((sum, r) => sum + r.impressions, 0),
+        }
+      : null,
+    byPositionGroup,
+    timeSeries,
+    previousPeriod,
+    topPagesByQueryCount,
+    // Measured against a live property: the API returns MORE query rows for a
+    // single device slice than for the unfiltered call over the same period
+    // (38,586 unfiltered vs 80,531 for MOBILE alone). Clicks stay consistent,
+    // so the filter itself is fine - the API simply surfaces more queries once
+    // the request is narrowed. Counts are therefore comparable only between
+    // runs with the SAME filter, never between filtered and unfiltered.
+    comparabilityWarning:
+      device || country
+        ? "A device or country filter is active. The API returns more query rows for a narrowed request than for the unfiltered one over the same period, so visibleQueries here is NOT comparable to an unfiltered run or to a run with a different filter - only to runs with this exact filter. Clicks and impressions are unaffected. For counts that stay comparable across slices, use the BigQuery bulk export (gsc_query_count in the BigQuery MCP), which does not truncate."
+        : null,
+  };
+}

--- a/src/tools/search-appearance.ts
+++ b/src/tools/search-appearance.ts
@@ -1,0 +1,120 @@
+import { fetchAllRows, getDateRange, SearchType } from "../analytics.js";
+
+interface AppearanceRow {
+  appearance: string;
+  clicks: number;
+  impressions: number;
+  ctr: number;
+  position: number;
+}
+
+interface DrillRow {
+  key: string;
+  clicks: number;
+  impressions: number;
+  ctr: number;
+  position: number;
+}
+
+interface SearchAppearanceResult {
+  surface: SearchType;
+  mode: "breakdown" | "drilldown";
+  period: { startDate: string; endDate: string };
+  appearanceBreakdown: AppearanceRow[];
+  drilldown?: {
+    appearance: string;
+    dimension: "page" | "query";
+    rows: DrillRow[];
+  };
+  note: string;
+}
+
+/**
+ * Search-appearance breakdown (rich-result / feature types). Common values include
+ * MERCHANT_LISTINGS (Händlereinträge), PRODUCT_SNIPPETS, REVIEW_SNIPPET,
+ * RECIPE_FEATURE, VIDEO, AMP_* and others — the exact set is whatever the property
+ * is eligible for. The API requires searchAppearance to be queried alone, so to see
+ * which pages/queries drive a given appearance you must filter on it (drilldown).
+ *
+ * @param appearance Optional. If provided, drills into that appearance type and
+ *                   returns the top pages (or queries) driving it.
+ */
+export async function searchAppearance(
+  days: number = 28,
+  appearance?: string,
+  drillDimension: "page" | "query" = "page",
+  searchType: SearchType = "web",
+  rowLimit: number = 50,
+  siteUrl?: string
+): Promise<SearchAppearanceResult> {
+  const period = getDateRange(days);
+
+  // Step 1: always fetch the full appearance breakdown (searchAppearance alone).
+  const breakdownRows = await fetchAllRows(
+    {
+      startDate: period.startDate,
+      endDate: period.endDate,
+      dimensions: ["searchAppearance"],
+      type: searchType,
+    },
+    siteUrl
+  );
+
+  const appearanceBreakdown: AppearanceRow[] = breakdownRows
+    .sort((a, b) => b.impressions - a.impressions)
+    .map((r) => ({
+      appearance: r.keys[0],
+      clicks: r.clicks,
+      impressions: r.impressions,
+      ctr: Math.round(r.ctr * 10000) / 100,
+      position: Math.round(r.position * 10) / 10,
+    }));
+
+  let drilldown: SearchAppearanceResult["drilldown"];
+
+  // Step 2: optional drilldown — filter on the appearance, group by page/query.
+  if (appearance) {
+    const drillRows = await fetchAllRows(
+      {
+        startDate: period.startDate,
+        endDate: period.endDate,
+        dimensions: [drillDimension],
+        type: searchType,
+        dimensionFilterGroups: [
+          {
+            filters: [
+              { dimension: "searchAppearance", operator: "equals", expression: appearance },
+            ],
+          },
+        ],
+      },
+      siteUrl
+    );
+
+    drilldown = {
+      appearance,
+      dimension: drillDimension,
+      rows: drillRows
+        .sort((a, b) => b.clicks - a.clicks)
+        .slice(0, Math.min(rowLimit, 200))
+        .map((r) => ({
+          key: r.keys[0],
+          clicks: r.clicks,
+          impressions: r.impressions,
+          ctr: Math.round(r.ctr * 10000) / 100,
+          position: Math.round(r.position * 10) / 10,
+        })),
+    };
+  }
+
+  return {
+    surface: searchType,
+    mode: appearance ? "drilldown" : "breakdown",
+    period,
+    appearanceBreakdown,
+    drilldown,
+    note: appearance
+      ? `Top ${drilldown?.dimension ?? "page"}s for appearance "${appearance}". Filtered via dimensionFilterGroups.`
+      : "Appearance-type breakdown. Pass an `appearance` value (e.g. MERCHANT_LISTINGS) to drill into the pages or queries driving it.",
+  };
+}


### PR DESCRIPTION
Fresh PR against current main, as asked in #5. Only the four pieces you said you wanted, no `dist/`, no rebase of the old branch. Supersedes #5, which can be closed.

No overlap with the image suite or the `type` parameter: everything the private branch already shipped is left alone, and the new tools use main's existing `type` field on `QueryParams`.

## What's in it

**`assertValidDimensions()` — clear errors instead of the API's 400** (`src/analytics.ts`)

`ALLOWED_DIMENSIONS` records which dimensions each search type actually accepts, and the guard names the offending dimension plus the legal set. It also enforces the one rule the API states but does not explain in its error: `searchAppearance` must be the only grouping dimension.

Wired into `advanced_search_analytics`, the one tool where the caller picks dimensions freely. Say the word and I'll extend it to the rest in a follow-up; I kept this PR to the one call site so the diff stays reviewable.

```
Dimension(s) [query] are not supported for type "discover". Allowed: [page, country, date, searchAppearance].
"searchAppearance" must be the only grouping dimension. To break a single appearance down by page or query, filter on searchAppearance instead.
```

**`discover_analysis`** — Discover in isolation. Feed-based, so no query rows and no meaningful position: top pages, country split, daily trend, prior-period comparison, and a note saying position does not apply here.

**`search_appearance`** — the `searchAppearance` dimension, which the image suite does not reach. Without an argument it lists every appearance type the property is eligible for (`PRODUCT_SNIPPETS`, `REVIEW_SNIPPET`, `MERCHANT_LISTINGS`, …); with one it drills into the pages or queries driving that type via a dimension filter, since the API refuses to group by it alongside anything else.

**`query_count`** — how many distinct queries a property, a section or a single URL is visible for, split by position group, optionally as a time series (day/week/month buckets, one request each), narrowable by position, device and country.

Two things it is deliberate about:

- It reports the **anonymized-click gap**: clicks the totals contain that no query row explains, because those queries sit below Google's privacy threshold. On the property I tested, that is 49% of clicks over 7 days. Without it, the query table reads as the complete keyword set, which it never is.
- With a device or country filter it attaches a **comparability warning**. Measured on a live property: the API returned 35,750 query rows unfiltered and 77,255 for MOBILE alone over the same week. Clicks stay consistent, so the filter works — the API simply surfaces more rows once the request narrows. Counts are therefore comparable only between runs with the same filter.

## Supporting changes

- `SearchType` is now an exported alias instead of the inline union in `QueryParams`, so the tools and the guard share one definition. `QueryParams.type` keeps its name and behaviour.
- `QueryParams.maxRows` plus the matching break in `fetchAllRows`, a hard cap across pages. `query_count` needs it for the expensive `page`+`query` pair (capped at 100k rows); every existing caller omits it and is unaffected.
- `deviceCountryFilters()`, the shared device/country filter builder `query_count` uses. It refuses a device filter on Discover, which has no device dimension, rather than silently returning nothing. This one was not on your list — it is here because `query_count`'s device and country parameters need it. If you'd rather not carry it: deleting the helper, the two zod parameters in `index.ts` and the two arguments in `queryCount()` removes the feature completely and touches nothing else.

Two commits: the shared groundwork in `analytics.ts` plus the `advanced_search_analytics` wiring, then the three tools and their registrations.

## Verification

`tsc --noEmit` clean. All three tools plus both guard paths run against the live API on this branch (service-account auth, `sc-domain:` property, 7-day window): Discover 369,049 clicks / 11,433,101 impressions, appearance breakdown returning `PRODUCT_SNIPPETS` and `REVIEW_SNIPPET`, `query_count` 35,750 queries across the five position groups.

No `dist/` in the diff, as requested.

## One observation, not part of this PR

`query_count`'s prior-period comparison reported 13,876 queries for the preceding week against 35,750 for the current one, +157%. That gap is too large to be real movement and looks like the same row-count variance the device warning describes, just across periods instead of filters. The comparison currently carries no warning for that. I'd rather investigate before adding one; flagging it here so the number is not read as a finding.
