### PR TITLE
Judge CTR against the property's own click curve, not the study table

### DIFF
--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -104,3 +104,83 @@ export async function fetchAllRows(params: QueryParams, siteUrlOverride?: string
 
   return allRows;
 }
+
+/**
+ * Expected CTR per position.
+ *
+ * The study table below comes from an industry-wide analysis of other people's
+ * sites. It is only the fallback now. Measured against a content property, the
+ * real CTR at position 1 is 3.5% against the table's 28.5% - a factor of 8.
+ * Judging pages against that stamps almost every page as underperforming, which
+ * says something about the study rather than about the page.
+ *
+ * So the tools build their own curve from the rows they already fetched and fall
+ * back to the table only for ranks with too little volume to measure reliably.
+ */
+export const STUDY_CTR_BY_POSITION = [
+  0.285, 0.157, 0.11, 0.08, 0.072, 0.051, 0.04, 0.032, 0.028, 0.025,
+];
+
+export function studyCtrAt(position: number): number {
+  if (position <= 0) return STUDY_CTR_BY_POSITION[0];
+  if (position <= 10) return STUDY_CTR_BY_POSITION[Math.floor(position) - 1];
+  return Math.max(0.005, 0.025 - (position - 10) * 0.002);
+}
+
+export type CtrSource = "measured" | "study";
+
+export interface ClickCurve {
+  /** Rank -> measured CTR as a fraction (0-1). */
+  byRank: Map<number, number>;
+  /** What the curve was built from, so the result stays interpretable. */
+  basis: string;
+  ranksMeasured: number;
+  impressionsConsidered: number;
+}
+
+/**
+ * Builds the CTR-per-rank curve from rows that were already fetched, so this
+ * costs no extra API call.
+ *
+ * CTR per rank is the sum of clicks over the sum of impressions, never a mean of
+ * ratios - otherwise a row with three impressions counts as much as one with
+ * thirty thousand. Call it on the unfiltered rows: build the curve after an
+ * impressions filter and it skews high.
+ */
+export function buildClickCurve(
+  rows: SearchAnalyticsRow[],
+  basis: string,
+  minImpressionsPerRank: number = 100
+): ClickCurve {
+  const buckets = new Map<number, { clicks: number; impressions: number }>();
+  let impressionsConsidered = 0;
+
+  for (const row of rows) {
+    if (!row.impressions) continue;
+    const rank = Math.max(1, Math.round(row.position));
+    const bucket = buckets.get(rank) || { clicks: 0, impressions: 0 };
+    bucket.clicks += row.clicks;
+    bucket.impressions += row.impressions;
+    buckets.set(rank, bucket);
+    impressionsConsidered += row.impressions;
+  }
+
+  const byRank = new Map<number, number>();
+  for (const [rank, bucket] of buckets) {
+    if (bucket.impressions < minImpressionsPerRank) continue;
+    byRank.set(rank, bucket.clicks / bucket.impressions);
+  }
+
+  return { byRank, basis, ranksMeasured: byRank.size, impressionsConsidered };
+}
+
+/** The measured CTR for this rank, else the study table. */
+export function expectedCtr(
+  position: number,
+  curve?: ClickCurve
+): { ctr: number; source: CtrSource } {
+  const rank = Math.max(1, Math.round(position));
+  const measured = curve?.byRank.get(rank);
+  if (measured !== undefined) return { ctr: measured, source: "measured" };
+  return { ctr: studyCtrAt(position), source: "study" };
+}

--- a/src/tools/ctr-opportunities.ts
+++ b/src/tools/ctr-opportunities.ts
@@ -1,12 +1,10 @@
-import { fetchAllRows, getDateRange } from "../analytics.js";
-
-const EXPECTED_CTR = [0.285, 0.157, 0.110, 0.080, 0.072, 0.051, 0.040, 0.032, 0.028, 0.025];
-
-function expectedCtrAtPosition(pos: number): number {
-  if (pos <= 0) return 0.285;
-  if (pos <= 10) return EXPECTED_CTR[Math.floor(pos) - 1];
-  return Math.max(0.005, 0.025 - (pos - 10) * 0.002);
-}
+import {
+  fetchAllRows,
+  getDateRange,
+  buildClickCurve,
+  expectedCtr,
+  CtrSource,
+} from "../analytics.js";
 
 interface CtrOpportunity {
   page: string;
@@ -17,6 +15,8 @@ interface CtrOpportunity {
   expectedCtr: number;
   ctrGap: number;
   potentialExtraClicks: number;
+  /** Where the expectation came from: this property's own curve, or the study table. */
+  expectedCtrSource: CtrSource;
 }
 
 export async function ctrOpportunities(
@@ -31,13 +31,17 @@ export async function ctrOpportunities(
     dimensions: ["page"],
   });
 
+  // Build the curve on the unfiltered rows, otherwise it skews high.
+  const curve = buildClickCurve(rows, "page rows of this request");
+
   const opportunities: CtrOpportunity[] = [];
 
   for (const row of rows) {
     if (row.impressions < minImpressions) continue;
     if (row.position > 20) continue; // only care about pages that rank somewhat
 
-    const expected = expectedCtrAtPosition(row.position);
+    const expectation = expectedCtr(row.position, curve);
+    const expected = expectation.ctr;
     const gap = expected - row.ctr;
 
     if (gap <= 0.01) continue; // CTR is at or above benchmark
@@ -49,6 +53,7 @@ export async function ctrOpportunities(
       ctr: Math.round(row.ctr * 10000) / 100,
       position: Math.round(row.position * 10) / 10,
       expectedCtr: Math.round(expected * 10000) / 100,
+      expectedCtrSource: expectation.source,
       ctrGap: Math.round(gap * 10000) / 100,
       potentialExtraClicks: Math.round(row.impressions * gap),
     });

--- a/src/tools/ctr-vs-benchmark.ts
+++ b/src/tools/ctr-vs-benchmark.ts
@@ -1,12 +1,10 @@
-import { fetchAllRows, getDateRange } from "../analytics.js";
-
-const BENCHMARK_CTR = [0.285, 0.157, 0.110, 0.080, 0.072, 0.051, 0.040, 0.032, 0.028, 0.025];
-
-function benchmarkCtr(pos: number): number {
-  if (pos <= 0) return 0.285;
-  if (pos <= 10) return BENCHMARK_CTR[Math.floor(pos) - 1];
-  return Math.max(0.005, 0.025 - (pos - 10) * 0.002);
-}
+import {
+  fetchAllRows,
+  getDateRange,
+  buildClickCurve,
+  expectedCtr,
+  CtrSource,
+} from "../analytics.js";
 
 interface CtrBenchmarkResult {
   page: string;
@@ -15,6 +13,8 @@ interface CtrBenchmarkResult {
   actualCtr: number;
   position: number;
   benchmarkCtr: number;
+  /** Where the benchmark came from: this property's own curve, or the study table. */
+  benchmarkSource: CtrSource;
   gap: number;
   verdict: string;
 }
@@ -31,13 +31,17 @@ export async function ctrVsBenchmark(
     dimensions: ["page"],
   });
 
+  // Build the curve on the unfiltered rows, otherwise it skews high.
+  const curve = buildClickCurve(rows, "page rows of this request");
+
   const results: CtrBenchmarkResult[] = [];
 
   for (const row of rows) {
     if (row.impressions < minImpressions) continue;
     if (row.position > 20) continue;
 
-    const benchmark = benchmarkCtr(row.position);
+    const expectation = expectedCtr(row.position, curve);
+    const benchmark = expectation.ctr;
     const gap = row.ctr - benchmark;
     const gapPercent = Math.round(gap * 10000) / 100;
 
@@ -59,6 +63,7 @@ export async function ctrVsBenchmark(
       actualCtr: Math.round(row.ctr * 10000) / 100,
       position: Math.round(row.position * 10) / 10,
       benchmarkCtr: Math.round(benchmark * 10000) / 100,
+      benchmarkSource: expectation.source,
       gap: gapPercent,
       verdict,
     });

--- a/src/tools/quick-wins.ts
+++ b/src/tools/quick-wins.ts
@@ -1,4 +1,10 @@
-import { fetchAllRows, getDateRange } from "../analytics.js";
+import {
+  fetchAllRows,
+  getDateRange,
+  buildClickCurve,
+  expectedCtr,
+  CtrSource,
+} from "../analytics.js";
 
 interface QuickWin {
   query: string;
@@ -7,15 +13,8 @@ interface QuickWin {
   ctr: number;
   position: number;
   opportunity: number;
-}
-
-// Expected CTR by position (used to estimate traffic gain if position improves)
-const EXPECTED_CTR = [0.285, 0.157, 0.110, 0.080, 0.072, 0.051, 0.040, 0.032, 0.028, 0.025];
-
-function expectedCtrAtPosition(pos: number): number {
-  if (pos <= 0) return 0.285;
-  if (pos <= 10) return EXPECTED_CTR[Math.floor(pos) - 1];
-  return Math.max(0.005, 0.025 - (pos - 10) * 0.002);
+  /** Where the target CTR came from: this property's own curve, or the study table. */
+  targetCtrSource: CtrSource;
 }
 
 export async function quickWins(
@@ -31,6 +30,9 @@ export async function quickWins(
     dimensions: ["query"],
   });
 
+  // Build the curve on the unfiltered rows, otherwise it skews high.
+  const curve = buildClickCurve(rows, "query rows of this request");
+
   const wins: QuickWin[] = [];
 
   for (const row of rows) {
@@ -41,9 +43,9 @@ export async function quickWins(
     if (impressions < minImpressions) continue;
 
     // Opportunity = impressions * (CTR at position 3 - current CTR)
-    const targetCtr = expectedCtrAtPosition(3);
+    const target = expectedCtr(3, curve);
     const currentCtr = row.ctr;
-    const opportunity = Math.round(impressions * Math.max(0, targetCtr - currentCtr));
+    const opportunity = Math.round(impressions * Math.max(0, target.ctr - currentCtr));
 
     wins.push({
       query: row.keys[0],
@@ -52,6 +54,7 @@ export async function quickWins(
       ctr: Math.round(row.ctr * 10000) / 100,
       position: Math.round(position * 10) / 10,
       opportunity,
+      targetCtrSource: target.source,
     });
   }
 


### PR DESCRIPTION
Separate from #10 and reviewable on its own — different tools, different part of `analytics.ts`, no dependency either way. Also no `dist/`.

This one is a correction to existing behaviour rather than a new feature, so the argument matters more than the diff.

## The problem

The table `[0.285, 0.157, 0.110, ...]` sits copied in three files and drives `ctr_vs_benchmark`, `ctr_opportunities` and — the one that weighs most — the `opportunity` score `quick_wins` sorts by. It comes from an industry-wide study of other people's sites.

Measured on a content property, 28 days, page dimension, 17,127 rows and 14.07M impressions:

| Rank | Measured | Study table |
|---|---|---|
| 1 | 6.82% | 28.50% |
| 2 | 1.68% | 15.70% |
| 3 | 3.40% | 11.00% |
| 5 | 1.89% | 7.20% |
| 10 | 1.31% | 2.50% |

What that does to the verdicts, same 6,603 eligible pages (≥200 impressions, position ≤20), both benchmarks applied to the identical rows:

| Verdict | Study table | Measured curve |
|---|---|---|
| Above benchmark | 112 | 406 |
| At benchmark | 2,139 | 5,948 |
| Below | 2,672 | 249 |
| Significantly below | 1,680 | 0 |

Against the table, two thirds of the property's pages are underperforming. That is not a finding about the pages — it is the study's audience mix, its SERP era and its branded-query share showing through. A benchmark that fails almost everything cannot rank what to fix, which is what these three tools exist to do.

## What this changes

Each tool builds a CTR-per-rank curve from the rows it already fetched — no extra API call. Details that matter:

- CTR per rank is **sum of clicks over sum of impressions**, never a mean of ratios. Otherwise a row with three impressions counts as much as one with thirty thousand.
- The curve is built **before** the impressions filter. Building it after keeps only the high-volume rows and skews the curve high.
- Ranks carrying **fewer than 100 impressions** fall back to the study table, so a thin rank does not produce a confident-looking number from noise.
- Every row reports which of the two it was judged against, in `benchmarkSource` / `expectedCtrSource` / `targetCtrSource`. No silent switch.
- The study table stays as the fallback, now in one place in `analytics.ts` instead of three copies.

## Two things I'd rather state than hide

**The correction is smaller on query rows than on page rows.** `quick_wins` targets position 3: 11.00% from the table, 3.40% from the page curve but 8.33% from the query curve on the same property. The dimension you aggregate over changes the answer, so `quick_wins` shifts less than `ctr_vs_benchmark` does. Both still shift.

**The ranking changes, but not wildly.** Top 50 `quick_wins` before and after: 49 of 50 are the same queries, but only 29 of 50 sit in the same position. Same candidates, different priority order — which is the part a user acts on.

**One property is not a calibration.** The evidence above is a single content site, and the measured rank-1 CTR of 6.82% is itself unusual — heavily branded properties will sit far higher. That is the argument for measuring per property rather than for replacing one fixed table with another.

## Verification

`tsc --noEmit` clean. All three tools run against the live API on this branch: 87 ranks measured, and all 50 returned rows in each of `quick_wins`, `ctr_opportunities` and `ctr_vs_benchmark` carry source `measured`, with the study fallback reached only on thin ranks.
